### PR TITLE
Rename ORB datastructures

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -13,9 +13,9 @@ PackageName := "datastructures",
 ##  one line.
 Subtitle := "datastructures is a collection of standard data structures for the GAP programming language",
 
-Version := "0.0.0",
+Version := "0.0.1",
 ##
-Date := "31/12/2013",
+Date := "31/08/2016",
 ##  Optional: if the package manual uses GAPDoc, you may duplicate the
 ##  version and the release date as shown below to read them while building
 ##  the manual using GAPDoc facilities to distibute documents across files.
@@ -24,10 +24,7 @@ Date := "31/12/2013",
 ##  <!ENTITY RELEASEDATE "31 December 2013">
 ##  <#/GAPDoc>
 
-PackageWWWHome :=
-  Concatenation( "http://www-groups.mcs.st-andrews.ac.uk/~markusp/",
-      LowercaseString( ~.PackageName ), "/" ),
-
+PackageWWWHome := "http://datastructures.github.io/",
 ArchiveURL := Concatenation( ~.PackageWWWHome, "datastructures-", ~.Version ),
 
 ArchiveFormats := ".tar.gz",

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ existing code and improving on it, in particular in view of HPC-GAP.
 
 The datastructures package consists of two parts: Interface declarations and implementations.
 
+While in the beta-phase we make no promises as to the stability of the interfaces
+or complexity promises, or documentation. Feel free to contribute your favourite datastructure
+and its implementation to this package using a pull-request.
+
 Interface Declarations
 ======================
 

--- a/gap/avltree.gd
+++ b/gap/avltree.gd
@@ -9,7 +9,7 @@
 ##  Copyright 2009-2009 by the authors.
 ##  This file is free software, see license information at the end.
 ##
-##  Declaration stuff for AVL trees in GAP.
+##  Declaration stuff for DS_AVL trees in GAP.
 ##
 ##  adding, removing and finding in O(log n), n is number of nodes
 ##
@@ -17,12 +17,12 @@
 ##
 #############################################################################
 
-BindGlobal( "AVLTreeFamily", NewFamily("AVLTreeFamily") );
-DeclareCategory( "IsAVLTree", IsPositionalObjectRep );
-DeclareRepresentation( "IsAVLTreeFlatRep", IsAVLTree, [] );
-BindGlobal( "AVLTreeType", NewType(AVLTreeFamily,IsAVLTreeFlatRep) );
-BindGlobal( "AVLTreeTypeMutable", NewType(AVLTreeFamily,
-                                          IsAVLTreeFlatRep and IsMutable) );
+BindGlobal( "DS_AVLTreeFamily", NewFamily("DS_AVLTreeFamily") );
+DeclareCategory( "IsDS_AVLTree", IsPositionalObjectRep );
+DeclareRepresentation( "IsDS_AVLTreeFlatRep", IsDS_AVLTree, [] );
+BindGlobal( "DS_AVLTreeType", NewType(DS_AVLTreeFamily,IsDS_AVLTreeFlatRep) );
+BindGlobal( "DS_AVLTreeTypeMutable", NewType(DS_AVLTreeFamily,
+                                          IsDS_AVLTreeFlatRep and IsMutable) );
 
 # All of the following functions exist on the GAP level and some of
 # them on the C level for speedup. The GAP versions have "_GAP" appended
@@ -30,32 +30,32 @@ BindGlobal( "AVLTreeTypeMutable", NewType(AVLTreeFamily,
 # nothing appended is the one to be used, it is assigned to the C
 # version if it is there and otherwise to the GAP version.
 
-DeclareGlobalFunction( "AVLCmp" );
-DeclareGlobalFunction( "AVLTree" );
-DeclareGlobalFunction( "AVLNewNode" );
-DeclareGlobalFunction( "AVLFreeNode" );
-DeclareGlobalFunction( "AVLData" );
-DeclareGlobalFunction( "AVLSetData" );
-DeclareGlobalFunction( "AVLLeft" );
-DeclareGlobalFunction( "AVLSetLeft" );
-DeclareGlobalFunction( "AVLRight" );
-DeclareGlobalFunction( "AVLSetRight" );
-DeclareGlobalFunction( "AVLRank" );
-DeclareGlobalFunction( "AVLSetRank" );
-DeclareGlobalFunction( "AVLBalFactor" );
-DeclareGlobalFunction( "AVLSetBalFactor" );
-DeclareGlobalFunction( "AVLValue" );
-DeclareGlobalFunction( "AVLSetValue" );
-DeclareGlobalFunction( "AVLFind" );
-DeclareGlobalFunction( "AVLFindIndex" );
-DeclareGlobalFunction( "AVLLookup" );
-DeclareGlobalFunction( "AVLIndex" );
-DeclareGlobalFunction( "AVLIndexFind" );
-DeclareGlobalFunction( "AVLRebalance" );
-DeclareGlobalFunction( "AVLIndexLookup" );
-DeclareGlobalFunction( "AVLAdd" );
-DeclareGlobalFunction( "AVLIndexAdd" );
-DeclareGlobalFunction( "AVLDelete" );
-DeclareGlobalFunction( "AVLIndexDelete" );
-DeclareGlobalFunction( "AVLToList" );
+DeclareGlobalFunction( "DS_AVLCmp" );
+DeclareGlobalFunction( "DS_AVLTree" );
+DeclareGlobalFunction( "DS_AVLNewNode" );
+DeclareGlobalFunction( "DS_AVLFreeNode" );
+DeclareGlobalFunction( "DS_AVLData" );
+DeclareGlobalFunction( "DS_AVLSetData" );
+DeclareGlobalFunction( "DS_AVLLeft" );
+DeclareGlobalFunction( "DS_AVLSetLeft" );
+DeclareGlobalFunction( "DS_AVLRight" );
+DeclareGlobalFunction( "DS_AVLSetRight" );
+DeclareGlobalFunction( "DS_AVLRank" );
+DeclareGlobalFunction( "DS_AVLSetRank" );
+DeclareGlobalFunction( "DS_AVLBalFactor" );
+DeclareGlobalFunction( "DS_AVLSetBalFactor" );
+DeclareGlobalFunction( "DS_AVLValue" );
+DeclareGlobalFunction( "DS_AVLSetValue" );
+DeclareGlobalFunction( "DS_AVLFind" );
+DeclareGlobalFunction( "DS_AVLFindIndex" );
+DeclareGlobalFunction( "DS_AVLLookup" );
+DeclareGlobalFunction( "DS_AVLIndex" );
+DeclareGlobalFunction( "DS_AVLIndexFind" );
+DeclareGlobalFunction( "DS_AVLRebalance" );
+DeclareGlobalFunction( "DS_AVLIndexLookup" );
+DeclareGlobalFunction( "DS_AVLAdd" );
+DeclareGlobalFunction( "DS_AVLIndexAdd" );
+DeclareGlobalFunction( "DS_AVLDelete" );
+DeclareGlobalFunction( "DS_AVLIndexDelete" );
+DeclareGlobalFunction( "DS_AVLToList" );
 

--- a/gap/avltree.gi
+++ b/gap/avltree.gi
@@ -9,7 +9,7 @@
 ##  Copyright 2009-2009 by the authors.
 ##  This file is free software, see license information at the end.
 ##
-##  Implementation stuff for AVL trees in GAP.
+##  Implementation stuff for DS_AVL trees in GAP.
 ##
 ##  adding, removing and finding in O(log n), n is number of nodes
 ##
@@ -21,7 +21,7 @@
 #
 # Conventions:
 #
-# A balanced binary tree (AVLTree) is a positional object having the
+# A balanced binary tree (DS_AVLTree) is a positional object having the
 # following entries:
 #   ![1]     len: last used entry (never shrinks), always = 3 mod 4
 #   ![2]     free: index of first freed entry, if 0, none free
@@ -46,7 +46,7 @@
 #                    2 - balance factor -1
 #
 
-AVLCmp_GAP := function(a,b)
+DS_AVLCmp_GAP := function(a,b)
   if a = b then
     return 0;
   elif a < b then
@@ -55,13 +55,13 @@ AVLCmp_GAP := function(a,b)
     return 1;
   fi;
 end;
-if IsBound(AVLCmp_C) then
-    InstallGlobalFunction(AVLCmp, AVLCmp_C);
+if IsBound(DS_AVLCmp_C) then
+    InstallGlobalFunction(DS_AVLCmp, DS_AVLCmp_C);
 else
-    InstallGlobalFunction(AVLCmp, AVLCmp_GAP);
+    InstallGlobalFunction(DS_AVLCmp, DS_AVLCmp_GAP);
 fi;
 
-AVLTree_GAP := function(arg)
+DS_AVLTree_GAP := function(arg)
   # Parameters: options record (optional)
   # Initializes balanced binary tree object, optionally with comparison
   # function. Returns empty tree object.
@@ -74,7 +74,7 @@ AVLTree_GAP := function(arg)
   # for the cmpfunc (or leave the default one).
   local t,cmpfunc,alloc,opt;
   # defaults:
-  cmpfunc := AVLCmp;
+  cmpfunc := DS_AVLCmp;
   alloc := 11;
   if Length(arg) = 1 then
       opt := arg[1];
@@ -97,27 +97,27 @@ AVLTree_GAP := function(arg)
           alloc := alloc*4+3;
       fi;
   elif Length(arg) <> 0 then
-      Error("Usage: AVLTree( [options-record] )");
+      Error("Usage: DS_AVLTree( [options-record] )");
       return fail;
   fi;
   t := [11,8,0,alloc,cmpfunc,0,fail,0,0,0,0];
   if alloc > 11 then t[alloc] := fail; fi;    # expand object
-  Objectify(AVLTreeTypeMutable,t);
+  Objectify(DS_AVLTreeTypeMutable,t);
   return t;
 end;
-if IsBound(AVLTree_C) then
-    InstallGlobalFunction(AVLTree, AVLTree_C);
+if IsBound(DS_AVLTree_C) then
+    InstallGlobalFunction(DS_AVLTree, DS_AVLTree_C);
 else
-    InstallGlobalFunction(AVLTree, AVLTree_GAP);
+    InstallGlobalFunction(DS_AVLTree, DS_AVLTree_GAP);
 fi;
 
 InstallMethod( ViewObj, "for an avltree object",
-  [IsAVLTree and IsAVLTreeFlatRep],
+  [IsDS_AVLTree and IsDS_AVLTreeFlatRep],
   function( t )
     Print("<avltree nodes=",t![3]," alloc=",t![4],">");
   end );
 
-AVLNewNode_GAP := function(t)
+DS_AVLNewNode_GAP := function(t)
   local n;
   if t![2] > 0 then
       n := t![2];
@@ -137,14 +137,14 @@ AVLNewNode_GAP := function(t)
   t![n+3] := 0;
   return n;
 end;
-if IsBound(AVLNewNode_C) then
-    InstallGlobalFunction(AVLNewNode, AVLNewNode_C);
+if IsBound(DS_AVLNewNode_C) then
+    InstallGlobalFunction(DS_AVLNewNode, DS_AVLNewNode_C);
 else
-    InstallGlobalFunction(AVLNewNode, AVLNewNode_GAP);
+    InstallGlobalFunction(DS_AVLNewNode, DS_AVLNewNode_GAP);
 fi;
 
 
-AVLFreeNode_GAP := function(t,n)
+DS_AVLFreeNode_GAP := function(t,n)
   local o;
   t![n] := t![2];
   t![2] := n;
@@ -156,94 +156,94 @@ AVLFreeNode_GAP := function(t,n)
   fi;
   return true;
 end;
-if IsBound(AVLFreeNode_C) then
-    InstallGlobalFunction(AVLFreeNode, AVLFreeNode_C);
+if IsBound(DS_AVLFreeNode_C) then
+    InstallGlobalFunction(DS_AVLFreeNode, DS_AVLFreeNode_C);
 else
-    InstallGlobalFunction(AVLFreeNode, AVLFreeNode_GAP);
+    InstallGlobalFunction(DS_AVLFreeNode, DS_AVLFreeNode_GAP);
 fi;
 
 
-AVLData_GAP := function(t,n)
+DS_AVLData_GAP := function(t,n)
   return t![n];
 end;
-if IsBound(AVLData_C) then
-    InstallGlobalFunction(AVLData, AVLData_C);
+if IsBound(DS_AVLData_C) then
+    InstallGlobalFunction(DS_AVLData, DS_AVLData_C);
 else
-    InstallGlobalFunction(AVLData, AVLData_GAP);
+    InstallGlobalFunction(DS_AVLData, DS_AVLData_GAP);
 fi;
 
 
-AVLSetData_GAP := function(t,n,d)
+DS_AVLSetData_GAP := function(t,n,d)
   t![n] := d;
 end;
-if IsBound(AVLSetData_C) then
-    InstallGlobalFunction(AVLSetData, AVLSetData_C);
+if IsBound(DS_AVLSetData_C) then
+    InstallGlobalFunction(DS_AVLSetData, DS_AVLSetData_C);
 else
-    InstallGlobalFunction(AVLSetData, AVLSetData_GAP);
+    InstallGlobalFunction(DS_AVLSetData, DS_AVLSetData_GAP);
 fi;
 
 
-AVLLeft_GAP := function(t,n)
+DS_AVLLeft_GAP := function(t,n)
   return QuoInt(t![n+1],4)*4;
 end;
-if IsBound(AVLLeft_C) then
-    InstallGlobalFunction(AVLLeft, AVLLeft_C);
+if IsBound(DS_AVLLeft_C) then
+    InstallGlobalFunction(DS_AVLLeft, DS_AVLLeft_C);
 else
-    InstallGlobalFunction(AVLLeft, AVLLeft_GAP);
+    InstallGlobalFunction(DS_AVLLeft, DS_AVLLeft_GAP);
 fi;
 
 
-AVLSetLeft_GAP := function(t,n,m)
+DS_AVLSetLeft_GAP := function(t,n,m)
   t![n+1] := m + t![n+1] mod 4;
 end;
-if IsBound(AVLSetLeft_C) then
-    InstallGlobalFunction(AVLSetLeft, AVLSetLeft_C);
+if IsBound(DS_AVLSetLeft_C) then
+    InstallGlobalFunction(DS_AVLSetLeft, DS_AVLSetLeft_C);
 else
-    InstallGlobalFunction(AVLSetLeft, AVLSetLeft_GAP);
+    InstallGlobalFunction(DS_AVLSetLeft, DS_AVLSetLeft_GAP);
 fi;
 
 
-AVLRight_GAP := function(t,n)
+DS_AVLRight_GAP := function(t,n)
   return QuoInt(t![n+2],4)*4;
 end;
-if IsBound(AVLRight_C) then
-    InstallGlobalFunction(AVLRight, AVLRight_C);
+if IsBound(DS_AVLRight_C) then
+    InstallGlobalFunction(DS_AVLRight, DS_AVLRight_C);
 else
-    InstallGlobalFunction(AVLRight, AVLRight_GAP);
+    InstallGlobalFunction(DS_AVLRight, DS_AVLRight_GAP);
 fi;
 
 
-AVLSetRight_GAP := function(t,n,m)
+DS_AVLSetRight_GAP := function(t,n,m)
   t![n+2] := m;
 end;
-if IsBound(AVLSetRight_C) then
-    InstallGlobalFunction(AVLSetRight, AVLSetRight_C);
+if IsBound(DS_AVLSetRight_C) then
+    InstallGlobalFunction(DS_AVLSetRight, DS_AVLSetRight_C);
 else
-    InstallGlobalFunction(AVLSetRight, AVLSetRight_GAP);
+    InstallGlobalFunction(DS_AVLSetRight, DS_AVLSetRight_GAP);
 fi;
 
 
-AVLRank_GAP := function(t,n)
+DS_AVLRank_GAP := function(t,n)
   return t![n+3];
 end;
-if IsBound(AVLRank_C) then
-    InstallGlobalFunction(AVLRank, AVLRank_C);
+if IsBound(DS_AVLRank_C) then
+    InstallGlobalFunction(DS_AVLRank, DS_AVLRank_C);
 else
-    InstallGlobalFunction(AVLRank, AVLRank_GAP);
+    InstallGlobalFunction(DS_AVLRank, DS_AVLRank_GAP);
 fi;
 
 
-AVLSetRank_GAP := function(t,n,r)
+DS_AVLSetRank_GAP := function(t,n,r)
   t![n+3] := r;
 end;
-if IsBound(AVLSetRank_C) then
-    InstallGlobalFunction(AVLSetRank, AVLSetRank_C);
+if IsBound(DS_AVLSetRank_C) then
+    InstallGlobalFunction(DS_AVLSetRank, DS_AVLSetRank_C);
 else
-    InstallGlobalFunction(AVLSetRank, AVLSetRank_GAP);
+    InstallGlobalFunction(DS_AVLSetRank, DS_AVLSetRank_GAP);
 fi;
 
 
-AVLBalFactor_GAP := function(t,n)
+DS_AVLBalFactor_GAP := function(t,n)
   local bf;
   bf := t![n+1] mod 4;    # 0, 1 or 2
   if bf = 2 then
@@ -252,27 +252,27 @@ AVLBalFactor_GAP := function(t,n)
     return bf;
   fi;
 end;
-if IsBound(AVLBalFactor_C) then
-    InstallGlobalFunction(AVLBalFactor, AVLBalFactor_C);
+if IsBound(DS_AVLBalFactor_C) then
+    InstallGlobalFunction(DS_AVLBalFactor, DS_AVLBalFactor_C);
 else
-    InstallGlobalFunction(AVLBalFactor, AVLBalFactor_GAP);
+    InstallGlobalFunction(DS_AVLBalFactor, DS_AVLBalFactor_GAP);
 fi;
 
 
-AVLSetBalFactor_GAP := function(t,n,bf)
+DS_AVLSetBalFactor_GAP := function(t,n,bf)
   if bf = -1 then
     t![n+1] := QuoInt(t![n+1],4)*4 + 2;
   else
     t![n+1] := QuoInt(t![n+1],4)*4 + bf;
   fi;
 end;
-if IsBound(AVLSetBalFactor_C) then
-    InstallGlobalFunction(AVLSetBalFactor, AVLSetBalFactor_C);
+if IsBound(DS_AVLSetBalFactor_C) then
+    InstallGlobalFunction(DS_AVLSetBalFactor, DS_AVLSetBalFactor_C);
 else
-    InstallGlobalFunction(AVLSetBalFactor, AVLSetBalFactor_GAP);
+    InstallGlobalFunction(DS_AVLSetBalFactor, DS_AVLSetBalFactor_GAP);
 fi;
 
-AVLValue_GAP := function(t,n)
+DS_AVLValue_GAP := function(t,n)
   if t![7] = fail then
       return true;
   elif not(IsBound(t![7][n/4])) then
@@ -281,37 +281,37 @@ AVLValue_GAP := function(t,n)
       return t![7][n/4];
   fi;
 end;
-if IsBound(AVLValue_C) then
-    InstallGlobalFunction(AVLValue, AVLValue_C);
+if IsBound(DS_AVLValue_C) then
+    InstallGlobalFunction(DS_AVLValue, DS_AVLValue_C);
 else
-    InstallGlobalFunction(AVLValue, AVLValue_GAP);
+    InstallGlobalFunction(DS_AVLValue, DS_AVLValue_GAP);
 fi;
 
-AVLSetValue_GAP := function(t,n,v)
+DS_AVLSetValue_GAP := function(t,n,v)
   n := n/4;
   if t![7] = fail then
       t![7] := EmptyPlist(n);
   fi;
   t![7][n] := v;
 end;
-if IsBound(AVLSetValue_C) then
-    InstallGlobalFunction(AVLSetValue, AVLSetValue_C);
+if IsBound(DS_AVLSetValue_C) then
+    InstallGlobalFunction(DS_AVLSetValue, DS_AVLSetValue_C);
 else
-    InstallGlobalFunction(AVLSetValue, AVLSetValue_GAP);
+    InstallGlobalFunction(DS_AVLSetValue, DS_AVLSetValue_GAP);
 fi;
 
 InstallMethod( Display, "for an avltree object",
-  [IsAVLTree and IsAVLTreeFlatRep],
+  [IsDS_AVLTree and IsDS_AVLTreeFlatRep],
   function( t )
     local DoRecursion;
     DoRecursion := function(p,depth,P)
       local i;
       if p = 0 then return; fi;
       for i in [1..depth] do Print(" "); od;
-      Print(P,"data=",AVLData(t,p)," rank=",AVLRank(t,p)," pos=",p,
-            " bf=",AVLBalFactor(t,p),"\n");
-      DoRecursion(AVLLeft(t,p),depth+1,"L:");
-      DoRecursion(AVLRight(t,p),depth+1,"R:");
+      Print(P,"data=",DS_AVLData(t,p)," rank=",DS_AVLRank(t,p)," pos=",p,
+            " bf=",DS_AVLBalFactor(t,p),"\n");
+      DoRecursion(DS_AVLLeft(t,p),depth+1,"L:");
+      DoRecursion(DS_AVLRight(t,p),depth+1,"R:");
     end;
 
     Print("<avltree nodes=",t![3]," alloc=",t![4],"\n");
@@ -319,9 +319,9 @@ InstallMethod( Display, "for an avltree object",
     Print(">\n");
   end );
 
-AVLFind_GAP := function(tree,data)
+DS_AVLFind_GAP := function(tree,data)
   # Parameters: tree, data
-  #  t is a AVL
+  #  t is a DS_AVL
   #  data is a data structure defined by the user
   # Searches in tree for a node equal to data, returns this node or fail
   # if not found.
@@ -329,42 +329,42 @@ AVLFind_GAP := function(tree,data)
   compare := tree![5];
   p := tree![6];
   while p >= 8 do
-    c := compare(data,AVLData(tree,p));
+    c := compare(data,DS_AVLData(tree,p));
     if c = 0 then
       return p;
-    elif c < 0 then    # data < AVLData(tree,p)
-      p := AVLLeft(tree,p);
-    else               # data > AVLData(tree,p)
-      p := AVLRight(tree,p);
+    elif c < 0 then    # data < DS_AVLData(tree,p)
+      p := DS_AVLLeft(tree,p);
+    else               # data > DS_AVLData(tree,p)
+      p := DS_AVLRight(tree,p);
     fi;
   od;
 
   return fail;
 end;
-if IsBound(AVLFind_C) then
-    InstallGlobalFunction(AVLFind, AVLFind_C);
+if IsBound(DS_AVLFind_C) then
+    InstallGlobalFunction(DS_AVLFind, DS_AVLFind_C);
 else
-    InstallGlobalFunction(AVLFind, AVLFind_GAP);
+    InstallGlobalFunction(DS_AVLFind, DS_AVLFind_GAP);
 fi;
 
-AVLLookup_GAP := function(t,d)
+DS_AVLLookup_GAP := function(t,d)
   local p;
-  p := AVLFind(t,d);
+  p := DS_AVLFind(t,d);
   if p = fail then
       return fail;
   else
-      return AVLValue(t,p);
+      return DS_AVLValue(t,p);
   fi;
 end;
-if IsBound(AVLLookup_C) then
-    InstallGlobalFunction(AVLLookup, AVLLookup_C);
+if IsBound(DS_AVLLookup_C) then
+    InstallGlobalFunction(DS_AVLLookup, DS_AVLLookup_C);
 else
-    InstallGlobalFunction(AVLLookup, AVLLookup_GAP);
+    InstallGlobalFunction(DS_AVLLookup, DS_AVLLookup_GAP);
 fi;
 
-AVLIndex_GAP := function(tree,index)
+DS_AVLIndex_GAP := function(tree,index)
   # Parameters: tree, index
-  #  tree is a AVL
+  #  tree is a DS_AVL
   #  index is an index in the tree
   # Searches in tree for the node with index index, returns the data of
   # this node or fail if not found. Works without comparison function,
@@ -379,29 +379,29 @@ AVLIndex_GAP := function(tree,index)
   offset := 0;         # Offset of subtree p in tree
 
   while true do   # will terminate!
-    r := offset + AVLRank(tree,p);
+    r := offset + DS_AVLRank(tree,p);
     if index < r then
       # go left
-      p := AVLLeft(tree,p);
+      p := DS_AVLLeft(tree,p);
     elif index = r then
       # found!
-      return AVLData(tree,p);
+      return DS_AVLData(tree,p);
     else
       # go right!
       offset := r;
-      p := AVLRight(tree,p);
+      p := DS_AVLRight(tree,p);
     fi;
   od;
 end;
-if IsBound(AVLIndex_C) then
-    InstallGlobalFunction(AVLIndex, AVLIndex_C);
+if IsBound(DS_AVLIndex_C) then
+    InstallGlobalFunction(DS_AVLIndex, DS_AVLIndex_C);
 else
-    InstallGlobalFunction(AVLIndex, AVLIndex_GAP);
+    InstallGlobalFunction(DS_AVLIndex, DS_AVLIndex_GAP);
 fi;
 
-AVLIndexFind_GAP := function(tree,index)
+DS_AVLIndexFind_GAP := function(tree,index)
   # Parameters: tree, index
-  #  tree is a AVL
+  #  tree is a DS_AVL
   #  index is an index in the tree
   # Searches in tree for the node with index index, returns the position of
   # this node or fail if not found. Works without comparison function,
@@ -416,42 +416,42 @@ AVLIndexFind_GAP := function(tree,index)
   offset := 0;         # Offset of subtree p in tree
 
   while true do   # will terminate!
-    r := offset + AVLRank(tree,p);
+    r := offset + DS_AVLRank(tree,p);
     if index < r then
       # go left
-      p := AVLLeft(tree,p);
+      p := DS_AVLLeft(tree,p);
     elif index = r then
       # found!
       return p;
     else
       # go right!
       offset := r;
-      p := AVLRight(tree,p);
+      p := DS_AVLRight(tree,p);
     fi;
   od;
 end;
-if IsBound(AVLIndexFind_C) then
-    InstallGlobalFunction(AVLIndexFind, AVLIndexFind_C);
+if IsBound(DS_AVLIndexFind_C) then
+    InstallGlobalFunction(DS_AVLIndexFind, DS_AVLIndexFind_C);
 else
-    InstallGlobalFunction(AVLIndexFind, AVLIndexFind_GAP);
+    InstallGlobalFunction(DS_AVLIndexFind, DS_AVLIndexFind_GAP);
 fi;
 
-AVLIndexLookup_GAP := function(tree,i)
+DS_AVLIndexLookup_GAP := function(tree,i)
   local p;
-  p := AVLIndexFind(tree,i);
+  p := DS_AVLIndexFind(tree,i);
   if p = fail then
       return fail;
   else
-      return AVLValue(tree,p);
+      return DS_AVLValue(tree,p);
   fi;
 end;
-if IsBound(AVLIndexLookup_C) then
-    InstallGlobalFunction(AVLIndexLookup, AVLIndexLookup_C);
+if IsBound(DS_AVLIndexLookup_C) then
+    InstallGlobalFunction(DS_AVLIndexLookup, DS_AVLIndexLookup_C);
 else
-    InstallGlobalFunction(AVLIndexLookup, AVLIndexLookup_GAP);
+    InstallGlobalFunction(DS_AVLIndexLookup, DS_AVLIndexLookup_GAP);
 fi;
 
-AVLRebalance_GAP := function(tree,q)
+DS_AVLRebalance_GAP := function(tree,q)
   # the tree starting at q has balanced subtrees but is out of balance:
   # the depth of the deeper subtree is 2 bigger than the depth of the other
   # tree. This function changes this situation following the procedure
@@ -462,32 +462,32 @@ AVLRebalance_GAP := function(tree,q)
   local shrink, p, l;
 
   shrink := true;   # in nearly all cases this happens
-  if AVLBalFactor(tree,q) < 0 then
-    p := AVLLeft(tree,q);
+  if DS_AVLBalFactor(tree,q) < 0 then
+    p := DS_AVLLeft(tree,q);
   else
-    p := AVLRight(tree,q);
+    p := DS_AVLRight(tree,q);
   fi;
-  if AVLBalFactor(tree,p) = AVLBalFactor(tree,q) then
+  if DS_AVLBalFactor(tree,p) = DS_AVLBalFactor(tree,q) then
     # we need a single rotation:
     #       q++             p=           q--          p=
     #      / \             / \          / \          / \
     #     a   p+    ==>   q=  c    OR  p-  c   ==>  a   q=
     #        / \         / \          / \              / \
     #       b   c       a   b        a   b            b   c
-    if AVLBalFactor(tree,q) > 0 then
-      AVLSetRight(tree,q,AVLLeft(tree,p));
-      AVLSetLeft(tree,p,q);
-      AVLSetBalFactor(tree,q,0);
-      AVLSetBalFactor(tree,p,0);
-      AVLSetRank(tree,p,AVLRank(tree,p) + AVLRank(tree,q));
+    if DS_AVLBalFactor(tree,q) > 0 then
+      DS_AVLSetRight(tree,q,DS_AVLLeft(tree,p));
+      DS_AVLSetLeft(tree,p,q);
+      DS_AVLSetBalFactor(tree,q,0);
+      DS_AVLSetBalFactor(tree,p,0);
+      DS_AVLSetRank(tree,p,DS_AVLRank(tree,p) + DS_AVLRank(tree,q));
     else
-      AVLSetLeft(tree,q,AVLRight(tree,p));
-      AVLSetRight(tree,p,q);
-      AVLSetBalFactor(tree,q,0);
-      AVLSetBalFactor(tree,p,0);
-      AVLSetRank(tree,q,AVLRank(tree,q) - AVLRank(tree,p));
+      DS_AVLSetLeft(tree,q,DS_AVLRight(tree,p));
+      DS_AVLSetRight(tree,p,q);
+      DS_AVLSetBalFactor(tree,q,0);
+      DS_AVLSetBalFactor(tree,p,0);
+      DS_AVLSetRank(tree,q,DS_AVLRank(tree,q) - DS_AVLRank(tree,p));
     fi;
-  elif AVLBalFactor(tree,p) = - AVLBalFactor(tree,q) then
+  elif DS_AVLBalFactor(tree,p) = - DS_AVLBalFactor(tree,q) then
     # we need a double rotation:
     #       q++                             q--
     #      / \             c=              / \            c=
@@ -496,82 +496,82 @@ AVLRebalance_GAP := function(tree,q)
     #       c   e      / \   / \        a   c         / \   / \
     #      / \        a   b d   e          / \       a   b d   e
     #     b   d                           b   d
-    if AVLBalFactor(tree,q) > 0 then
-      l := AVLLeft(tree,p);
-      AVLSetRight(tree,q,AVLLeft(tree,l));
-      AVLSetLeft(tree,p,AVLRight(tree,l));
-      AVLSetLeft(tree,l,q);
-      AVLSetRight(tree,l,p);
-      if AVLBalFactor(tree,l) > 0 then
-        AVLSetBalFactor(tree,p,0);
-        AVLSetBalFactor(tree,q,-1);
-      elif AVLBalFactor(tree,l) = 0 then
-        AVLSetBalFactor(tree,p,0);
-        AVLSetBalFactor(tree,q,0);
-      else    # AVLBalFactor(tree,l) < 0
-        AVLSetBalFactor(tree,p,1);
-        AVLSetBalFactor(tree,q,0);
+    if DS_AVLBalFactor(tree,q) > 0 then
+      l := DS_AVLLeft(tree,p);
+      DS_AVLSetRight(tree,q,DS_AVLLeft(tree,l));
+      DS_AVLSetLeft(tree,p,DS_AVLRight(tree,l));
+      DS_AVLSetLeft(tree,l,q);
+      DS_AVLSetRight(tree,l,p);
+      if DS_AVLBalFactor(tree,l) > 0 then
+        DS_AVLSetBalFactor(tree,p,0);
+        DS_AVLSetBalFactor(tree,q,-1);
+      elif DS_AVLBalFactor(tree,l) = 0 then
+        DS_AVLSetBalFactor(tree,p,0);
+        DS_AVLSetBalFactor(tree,q,0);
+      else    # DS_AVLBalFactor(tree,l) < 0
+        DS_AVLSetBalFactor(tree,p,1);
+        DS_AVLSetBalFactor(tree,q,0);
       fi;
-      AVLSetBalFactor(tree,l,0);
-      AVLSetRank(tree,p,AVLRank(tree,p) - AVLRank(tree,l));
-      AVLSetRank(tree,l,AVLRank(tree,l) + AVLRank(tree,q));
+      DS_AVLSetBalFactor(tree,l,0);
+      DS_AVLSetRank(tree,p,DS_AVLRank(tree,p) - DS_AVLRank(tree,l));
+      DS_AVLSetRank(tree,l,DS_AVLRank(tree,l) + DS_AVLRank(tree,q));
       p := l;
     else
-      l := AVLRight(tree,p);
-      AVLSetLeft(tree,q,AVLRight(tree,l));
-      AVLSetRight(tree,p,AVLLeft(tree,l));
-      AVLSetLeft(tree,l,p);
-      AVLSetRight(tree,l,q);
-      if AVLBalFactor(tree,l) < 0 then
-        AVLSetBalFactor(tree,p,0);
-        AVLSetBalFactor(tree,q,1);
-      elif AVLBalFactor(tree,l) = 0 then
-        AVLSetBalFactor(tree,p,0);
-        AVLSetBalFactor(tree,q,0);
-      else    # AVLBalFactor(tree,l) > 0
-        AVLSetBalFactor(tree,p,-1);
-        AVLSetBalFactor(tree,q,0);
+      l := DS_AVLRight(tree,p);
+      DS_AVLSetLeft(tree,q,DS_AVLRight(tree,l));
+      DS_AVLSetRight(tree,p,DS_AVLLeft(tree,l));
+      DS_AVLSetLeft(tree,l,p);
+      DS_AVLSetRight(tree,l,q);
+      if DS_AVLBalFactor(tree,l) < 0 then
+        DS_AVLSetBalFactor(tree,p,0);
+        DS_AVLSetBalFactor(tree,q,1);
+      elif DS_AVLBalFactor(tree,l) = 0 then
+        DS_AVLSetBalFactor(tree,p,0);
+        DS_AVLSetBalFactor(tree,q,0);
+      else    # DS_AVLBalFactor(tree,l) > 0
+        DS_AVLSetBalFactor(tree,p,-1);
+        DS_AVLSetBalFactor(tree,q,0);
       fi;
-      AVLSetBalFactor(tree,l,0);
-      AVLSetRank(tree,l,AVLRank(tree,l) + AVLRank(tree,p));
-      AVLSetRank(tree,q,AVLRank(tree,q) - AVLRank(tree,l));
-                           # new value of AVLRank(tree,l)!
+      DS_AVLSetBalFactor(tree,l,0);
+      DS_AVLSetRank(tree,l,DS_AVLRank(tree,l) + DS_AVLRank(tree,p));
+      DS_AVLSetRank(tree,q,DS_AVLRank(tree,q) - DS_AVLRank(tree,l));
+                           # new value of DS_AVLRank(tree,l)!
       p := l;
     fi;
-  else   # AVLBalFactor(tree,p) = 0 then
+  else   # DS_AVLBalFactor(tree,p) = 0 then
     # we need a single rotation:
     #       q++             p-           q--          p+
     #      / \             / \          / \          / \
     #     a   p=    ==>   q+  c    OR  p=  c   ==>  a   q-
     #        / \         / \          / \              / \
     #       b   c       a   b        a   b            b   c
-    if AVLBalFactor(tree,q) > 0 then
-      AVLSetRight(tree,q,AVLLeft(tree,p));
-      AVLSetLeft(tree,p,q);
-      AVLSetBalFactor(tree,q,1);
-      AVLSetBalFactor(tree,p,-1);
-      AVLSetRank(tree,p,AVLRank(tree,p) + AVLRank(tree,q));
+    if DS_AVLBalFactor(tree,q) > 0 then
+      DS_AVLSetRight(tree,q,DS_AVLLeft(tree,p));
+      DS_AVLSetLeft(tree,p,q);
+      DS_AVLSetBalFactor(tree,q,1);
+      DS_AVLSetBalFactor(tree,p,-1);
+      DS_AVLSetRank(tree,p,DS_AVLRank(tree,p) + DS_AVLRank(tree,q));
     else
-      AVLSetLeft(tree,q,AVLRight(tree,p));
-      AVLSetRight(tree,p,q);
-      AVLSetBalFactor(tree,q,-1);
-      AVLSetBalFactor(tree,p,1);
-      AVLSetRank(tree,q,AVLRank(tree,q) - AVLRank(tree,p));
+      DS_AVLSetLeft(tree,q,DS_AVLRight(tree,p));
+      DS_AVLSetRight(tree,p,q);
+      DS_AVLSetBalFactor(tree,q,-1);
+      DS_AVLSetBalFactor(tree,p,1);
+      DS_AVLSetRank(tree,q,DS_AVLRank(tree,q) - DS_AVLRank(tree,p));
     fi;
     shrink := false;
   fi;
   return rec(newroot := p, shorter := shrink);
 end;
-if IsBound(AVLRebalance_C) then
-    InstallGlobalFunction(AVLRebalance, AVLRebalance_C);
+if IsBound(DS_AVLRebalance_C) then
+    InstallGlobalFunction(DS_AVLRebalance, DS_AVLRebalance_C);
 else
-    InstallGlobalFunction(AVLRebalance, AVLRebalance_GAP);
+    InstallGlobalFunction(DS_AVLRebalance, DS_AVLRebalance_GAP);
 fi;
 
 
-AVLAdd_GAP := function(tree,data,value)
+DS_AVLAdd_GAP := function(tree,data,value)
   # Parameters: tree, data, value
-  #  tree is a AVL
+  #  tree is a DS_AVL
   #  data is a data structure defined by the user
   #  value is the value stored under the key data, if true, nothing is stored
   # Tries to add the data as a node in tree. It is an error, if there is
@@ -585,14 +585,14 @@ AVLAdd_GAP := function(tree,data,value)
 
   p := tree![6];
   if p = 0 then   # A new, single node in the tree
-    new := AVLNewNode(tree);
-    AVLSetLeft(tree,new,0);
-    AVLSetRight(tree,new,0);
-    AVLSetBalFactor(tree,new,0);
-    AVLSetRank(tree,new,1);
-    AVLSetData(tree,new,data);
+    new := DS_AVLNewNode(tree);
+    DS_AVLSetLeft(tree,new,0);
+    DS_AVLSetRight(tree,new,0);
+    DS_AVLSetBalFactor(tree,new,0);
+    DS_AVLSetRank(tree,new,1);
+    DS_AVLSetData(tree,new,data);
     if value <> true then
-        AVLSetValue(tree,new,value);
+        DS_AVLSetValue(tree,new,value);
     fi;
     tree![3] := 1;
     tree![6] := new;
@@ -615,26 +615,26 @@ AVLAdd_GAP := function(tree,data,value)
   repeat
 
     # do we have to remember this position?
-    if AVLBalFactor(tree,p) <> 0 then
+    if DS_AVLBalFactor(tree,p) <> 0 then
       q := n;       # forget old last node with balance factor <> 0
     fi;
 
     # now one step:
-    c := compare(data,AVLData(tree,p));
+    c := compare(data,DS_AVLData(tree,p));
     if c = 0 then   # we did not want this!
       for p in rankadds do
-        AVLSetRank(tree,p,AVLRank(tree,p) - 1);
+        DS_AVLSetRank(tree,p,DS_AVLRank(tree,p) - 1);
       od;
       return fail; # tree is unchanged
     fi;
 
     l := p;     # remember last position
-    if c < 0 then   # data < AVLData(tree,p)
-      AVLSetRank(tree,p,AVLRank(tree,p) + 1);
+    if c < 0 then   # data < DS_AVLData(tree,p)
+      DS_AVLSetRank(tree,p,DS_AVLRank(tree,p) + 1);
       Add(rankadds,p);
-      p := AVLLeft(tree,p);
-    else            # data > AVLData(tree,p)
-      p := AVLRight(tree,p);
+      p := DS_AVLLeft(tree,p);
+    else            # data > DS_AVLData(tree,p)
+      p := DS_AVLRight(tree,p);
     fi;
     Add(nodes,p);
     n := n + 1;
@@ -647,64 +647,64 @@ AVLAdd_GAP := function(tree,data,value)
   l := nodes[n-1];   # for easier reference
 
   # a new node:
-  p := AVLNewNode(tree);
-  AVLSetLeft(tree,p,0);
-  AVLSetRight(tree,p,0);
-  AVLSetBalFactor(tree,p,0);
-  AVLSetRank(tree,p,1);
-  AVLSetData(tree,p,data);
+  p := DS_AVLNewNode(tree);
+  DS_AVLSetLeft(tree,p,0);
+  DS_AVLSetRight(tree,p,0);
+  DS_AVLSetBalFactor(tree,p,0);
+  DS_AVLSetRank(tree,p,1);
+  DS_AVLSetData(tree,p,data);
   if value <> true then
-      AVLSetValue(tree,p,value);
+      DS_AVLSetValue(tree,p,value);
   fi;
   # insert into tree:
   if c < 0 then    # left
-    AVLSetLeft(tree,l,p);
+    DS_AVLSetLeft(tree,l,p);
   else
-    AVLSetRight(tree,l,p);
+    DS_AVLSetRight(tree,l,p);
   fi;
   tree![3] := tree![3] + 1;
 
   # modify balance factors between q and l:
   for i in [q+1..n-1] do
-    AVLSetBalFactor(tree,nodes[i],path[i]);
+    DS_AVLSetBalFactor(tree,nodes[i],path[i]);
   od;
 
   # is rebalancing at q necessary?
   if q = 0 then    # whole tree has grown one step
     return true;   # Success!
   fi;
-  if AVLBalFactor(tree,nodes[q]) = -path[q] then
+  if DS_AVLBalFactor(tree,nodes[q]) = -path[q] then
     # the subtree at q has gotten more balanced
-    AVLSetBalFactor(tree,nodes[q],0);
+    DS_AVLSetBalFactor(tree,nodes[q],0);
     return true;   # Success!
   fi;
 
   # now at last we do have to rebalance at nodes[q] because the tree has
   # gotten out of balance:
-  p := AVLRebalance(tree,nodes[q]);
+  p := DS_AVLRebalance(tree,nodes[q]);
   p := p.newroot;
 
   # finishing touch: link new root of subtree (p) to t:
   if q = 1 then  # q resp. r was First node
     tree![6] := p;
   elif path[q-1] = -1 then
-    AVLSetLeft(tree,nodes[q-1],p);
+    DS_AVLSetLeft(tree,nodes[q-1],p);
   else
-    AVLSetRight(tree,nodes[q-1],p);
+    DS_AVLSetRight(tree,nodes[q-1],p);
   fi;
 
   return true;
 end;
-if IsBound(AVLAdd_C) then
-    InstallGlobalFunction(AVLAdd, AVLAdd_C);
+if IsBound(DS_AVLAdd_C) then
+    InstallGlobalFunction(DS_AVLAdd, DS_AVLAdd_C);
 else
-    InstallGlobalFunction(AVLAdd, AVLAdd_GAP);
+    InstallGlobalFunction(DS_AVLAdd, DS_AVLAdd_GAP);
 fi;
 
 
-AVLIndexAdd_GAP := function(tree,data,value,index)
+DS_AVLIndexAdd_GAP := function(tree,data,value,index)
   # Parameters: index, data, value, tree
-  #  tree is a AVL
+  #  tree is a DS_AVL
   #  data is a data structure defined by the user
   #  value is the value to be stored under key data, nothing is stored if true
   #  index is the index, where data should be inserted in tree 1 ist at
@@ -721,14 +721,14 @@ AVLIndexAdd_GAP := function(tree,data,value,index)
   p := tree![6];
   if p = 0 then   # A new, single node in the tree
     # index must be equal to 1
-    tree![6] := AVLNewNode(tree);
-    AVLSetLeft(tree,tree![6],0);
-    AVLSetRight(tree,tree![6],0);
-    AVLSetBalFactor(tree,tree![6],0);
-    AVLSetRank(tree,tree![6],1);
-    AVLSetData(tree,tree![6],data);
+    tree![6] := DS_AVLNewNode(tree);
+    DS_AVLSetLeft(tree,tree![6],0);
+    DS_AVLSetRight(tree,tree![6],0);
+    DS_AVLSetBalFactor(tree,tree![6],0);
+    DS_AVLSetRank(tree,tree![6],1);
+    DS_AVLSetData(tree,tree![6],data);
     if value <> true then
-        AVLSetValue(tree,tree![6],value);
+        DS_AVLSetValue(tree,tree![6],value);
     fi;
     tree![3] := 1;
     return true;
@@ -750,24 +750,24 @@ AVLIndexAdd_GAP := function(tree,data,value,index)
   repeat
 
     # do we have to remember this position?
-    if AVLBalFactor(tree,p) <> 0 then
+    if DS_AVLBalFactor(tree,p) <> 0 then
       q := n;       # forget old last node with balance factor <> 0
     fi;
 
     # now one step:
-    if index <= offset+AVLRank(tree,p) then
+    if index <= offset+DS_AVLRank(tree,p) then
       c := -1;    # we have to descend to left subtree
     else
       c := +1;    # we have to descend to right subtree
     fi;
 
     l := p;     # remember last position
-    if c < 0 then   # data < AVLData(tree,p)
-      AVLSetRank(tree,p,AVLRank(tree,p) + 1);
-      p := AVLLeft(tree,p);
-    else            # data > AVLData(tree,p)
-      offset := offset + AVLRank(tree,p);
-      p := AVLRight(tree,p);
+    if c < 0 then   # data < DS_AVLData(tree,p)
+      DS_AVLSetRank(tree,p,DS_AVLRank(tree,p) + 1);
+      p := DS_AVLLeft(tree,p);
+    else            # data > DS_AVLData(tree,p)
+      offset := offset + DS_AVLRank(tree,p);
+      p := DS_AVLRight(tree,p);
     fi;
     Add(nodes,p);
     n := n + 1;
@@ -780,63 +780,63 @@ AVLIndexAdd_GAP := function(tree,data,value,index)
   l := nodes[n-1];   # for easier reference
 
   # a new node:
-  p := AVLNewNode(tree);
-  AVLSetLeft(tree,p,0);
-  AVLSetRight(tree,p,0);
-  AVLSetBalFactor(tree,p,0);
-  AVLSetRank(tree,p,1);
-  AVLSetData(tree,p,data);
+  p := DS_AVLNewNode(tree);
+  DS_AVLSetLeft(tree,p,0);
+  DS_AVLSetRight(tree,p,0);
+  DS_AVLSetBalFactor(tree,p,0);
+  DS_AVLSetRank(tree,p,1);
+  DS_AVLSetData(tree,p,data);
   if value <> true then
-      AVLSetValue(tree,p,value);
+      DS_AVLSetValue(tree,p,value);
   fi;
   # insert into tree:
   if c < 0 then    # left
-    AVLSetLeft(tree,l,p);
+    DS_AVLSetLeft(tree,l,p);
   else
-    AVLSetRight(tree,l,p);
+    DS_AVLSetRight(tree,l,p);
   fi;
   tree![3] := tree![3] + 1;
 
   # modify balance factors between q and l:
   for i in [q+1..n-1] do
-    AVLSetBalFactor(tree,nodes[i],path[i]);
+    DS_AVLSetBalFactor(tree,nodes[i],path[i]);
   od;
 
   # is rebalancing at q necessary?
   if q = 0 then    # whole tree has grown one step
     return true;   # Success!
   fi;
-  if AVLBalFactor(tree,nodes[q]) = -path[q] then
+  if DS_AVLBalFactor(tree,nodes[q]) = -path[q] then
     # the subtree at q has gotten more balanced
-    AVLSetBalFactor(tree,nodes[q],0);
+    DS_AVLSetBalFactor(tree,nodes[q],0);
     return true;   # Success!
   fi;
 
   # now at last we do have to rebalance at nodes[q] because the tree has
   # gotten out of balance:
-  p := AVLRebalance(tree,nodes[q]);
+  p := DS_AVLRebalance(tree,nodes[q]);
   p := p.newroot;
 
   # finishing touch: link new root of subtree (p) to t:
   if q = 1 then  # q resp. r was First node
     tree![6] := p;
   elif path[q-1] = -1 then
-    AVLSetLeft(tree,nodes[q-1],p);
+    DS_AVLSetLeft(tree,nodes[q-1],p);
   else
-    AVLSetRight(tree,nodes[q-1],p);
+    DS_AVLSetRight(tree,nodes[q-1],p);
   fi;
 
   return true;
 end;
-if IsBound(AVLIndexAdd_C) then
-    InstallGlobalFunction(AVLIndexAdd, AVLIndexAdd_C);
+if IsBound(DS_AVLIndexAdd_C) then
+    InstallGlobalFunction(DS_AVLIndexAdd, DS_AVLIndexAdd_C);
 else
-    InstallGlobalFunction(AVLIndexAdd, AVLIndexAdd_GAP);
+    InstallGlobalFunction(DS_AVLIndexAdd, DS_AVLIndexAdd_GAP);
 fi;
 
-AVLDelete_GAP := function(tree,data)
+DS_AVLDelete_GAP := function(tree,data)
   # Parameters: tree, data
-  #  tree is a AVL
+  #  tree is a DS_AVL
   #  data is a data structure defined by the user
   # Tries to find data as a node in the tree. If found, this node is deleted
   # and the tree rebalanced. It is an error, if the node is not found.
@@ -850,10 +850,10 @@ AVLDelete_GAP := function(tree,data)
     return fail;
   fi;
   if tree![3] = 1 then
-    if compare(data,AVLData(tree,p)) = 0 then
+    if compare(data,DS_AVLData(tree,p)) = 0 then
       tree![3] := 0;
       tree![6] := 0;
-      return AVLFreeNode(tree,p);
+      return DS_AVLFreeNode(tree,p);
     else
       return fail;
     fi;
@@ -872,15 +872,15 @@ AVLDelete_GAP := function(tree,data)
   repeat
 
     # what is the next step?
-    c := compare(data,AVLData(tree,p));
+    c := compare(data,DS_AVLData(tree,p));
 
     if c <> 0 then  # only if data not found!
-      if c < 0 then       # data < AVLData(tree,p)
-        AVLSetRank(tree,p,AVLRank(tree,p) - 1);
+      if c < 0 then       # data < DS_AVLData(tree,p)
+        DS_AVLSetRank(tree,p,DS_AVLRank(tree,p) - 1);
         Add(ranksubs,p);
-        p := AVLLeft(tree,p);
-      elif c > 0 then     # data > AVLData(tree,p)
-        p := AVLRight(tree,p);
+        p := DS_AVLLeft(tree,p);
+      elif c > 0 then     # data > DS_AVLData(tree,p)
+        p := DS_AVLRight(tree,p);
       fi;
       Add(nodes,p);
       n := n + 1;
@@ -890,55 +890,55 @@ AVLDelete_GAP := function(tree,data)
     if p = 0 then
       # error, we did not find data
       for i in ranksubs do
-        AVLSetRank(tree,i,AVLRank(tree,i) + 1);
+        DS_AVLSetRank(tree,i,DS_AVLRank(tree,i) + 1);
       od;
       return fail;
     fi;
 
   until c = 0;   # until we find the right node
-  # now data is equal to AVLData(tree,p,) so this node p must be removed.
+  # now data is equal to DS_AVLData(tree,p,) so this node p must be removed.
   # the tree must be modified between tree![6] and nodes[n] along path
   # Ranks are already done up there
 
   # now we have to search a neighbour, we modify "nodes" and "path" but not n!
   m := n;
-  if AVLBalFactor(tree,p) < 0 then   # search to the left
-    l := AVLLeft(tree,p);   # must be a node!
-    AVLSetRank(tree,p,AVLRank(tree,p) - 1);
+  if DS_AVLBalFactor(tree,p) < 0 then   # search to the left
+    l := DS_AVLLeft(tree,p);   # must be a node!
+    DS_AVLSetRank(tree,p,DS_AVLRank(tree,p) - 1);
     # we will delete in left subtree!
     Add(nodes,l);
     m := m + 1;
     Add(path,-1);
-    while AVLRight(tree,l) <> 0 do
-      l := AVLRight(tree,l);
+    while DS_AVLRight(tree,l) <> 0 do
+      l := DS_AVLRight(tree,l);
       Add(nodes,l);
       m := m + 1;
       Add(path,1);
     od;
     c := -1;       # we got predecessor
-  elif AVLBalFactor(tree,p) > 0 then    # search to the right
-    l := AVLRight(tree,p);  # must be a node!
+  elif DS_AVLBalFactor(tree,p) > 0 then    # search to the right
+    l := DS_AVLRight(tree,p);  # must be a node!
     Add(nodes,l);
     m := m + 1;
     Add(path,1);
-    while AVLLeft(tree,l) <> 0 do
-      AVLSetRank(tree,l,AVLRank(tree,l) - 1);
+    while DS_AVLLeft(tree,l) <> 0 do
+      DS_AVLSetRank(tree,l,DS_AVLRank(tree,l) - 1);
       # we will delete in left subtree!
-      l := AVLLeft(tree,l);
+      l := DS_AVLLeft(tree,l);
       Add(nodes,l);
       m := m + 1;
       Add(path,-1);
     od;
     c := 1;        # we got successor
   else   # equal depths
-    if AVLLeft(tree,p) <> 0 then
-      l := AVLLeft(tree,p);
-      AVLSetRank(tree,p,AVLRank(tree,p) - 1);
+    if DS_AVLLeft(tree,p) <> 0 then
+      l := DS_AVLLeft(tree,p);
+      DS_AVLSetRank(tree,p,DS_AVLRank(tree,p) - 1);
       Add(nodes,l);
       m := m + 1;
       Add(path,-1);
-      while AVLRight(tree,l) <> 0 do
-        l := AVLRight(tree,l);
+      while DS_AVLRight(tree,l) <> 0 do
+        l := DS_AVLRight(tree,l);
         Add(nodes,l);
         m := m + 1;
         Add(path,1);
@@ -954,23 +954,23 @@ AVLDelete_GAP := function(tree,data)
   # "nodes" and "path" is updated, but n could be < m
 
   # Copy Data from l up to p: order is NOT modified
-  AVLSetData(tree,p,AVLData(tree,l));
+  DS_AVLSetData(tree,p,DS_AVLData(tree,l));
      # works for m = n, i.e. if p is end node
 
   # Delete node at l = nodes[m] by modifying nodes[m-1]:
   # Note: nodes[m] has maximal one subtree!
   if c <= 0 then
-    r := AVLLeft(tree,l);
+    r := DS_AVLLeft(tree,l);
   else  #  c > 0
-    r := AVLRight(tree,l);
+    r := DS_AVLRight(tree,l);
   fi;
   if path[m-1] < 0 then
-    AVLSetLeft(tree,nodes[m-1],r);
+    DS_AVLSetLeft(tree,nodes[m-1],r);
   else
-    AVLSetRight(tree,nodes[m-1],r);
+    DS_AVLSetRight(tree,nodes[m-1],r);
   fi;
   tree![3] := tree![3] - 1;
-  old := AVLFreeNode(tree,l);
+  old := DS_AVLFreeNode(tree,l);
 
   # modify balance factors:
   # the subtree nodes[m-1] has become shorter at its left (resp. right)
@@ -980,20 +980,20 @@ AVLDelete_GAP := function(tree,data)
   # (we decrement m and work until the corresponding subtree has not shrunk)
   m := m - 1;  # start work HERE
   while m >= 1 do
-    if AVLBalFactor(tree,nodes[m]) = 0 then
-      AVLSetBalFactor(tree,nodes[m],-path[m]);  # we made path[m] shorter
+    if DS_AVLBalFactor(tree,nodes[m]) = 0 then
+      DS_AVLSetBalFactor(tree,nodes[m],-path[m]);  # we made path[m] shorter
       return old;
-    elif AVLBalFactor(tree,nodes[m]) = path[m] then
-      AVLSetBalFactor(tree,nodes[m],0);         # we made path[m] shorter
+    elif DS_AVLBalFactor(tree,nodes[m]) = path[m] then
+      DS_AVLSetBalFactor(tree,nodes[m],0);         # we made path[m] shorter
     else    # tree is out of balance
-      p := AVLRebalance(tree,nodes[m]);
+      p := DS_AVLRebalance(tree,nodes[m]);
       if m = 1 then
         tree![6] := p.newroot;
         return old;               # everything is done
       elif path[m-1] = -1 then
-        AVLSetLeft(tree,nodes[m-1],p.newroot);
+        DS_AVLSetLeft(tree,nodes[m-1],p.newroot);
       else
-        AVLSetRight(tree,nodes[m-1],p.newroot);
+        DS_AVLSetRight(tree,nodes[m-1],p.newroot);
       fi;
       if not p.shorter then return old; fi;   # nothing happens further up
     fi;
@@ -1001,17 +1001,17 @@ AVLDelete_GAP := function(tree,data)
   od;
   return old;
 end;
-if IsBound(AVLDelete_C) then
-    InstallGlobalFunction(AVLDelete, AVLDelete_C);
+if IsBound(DS_AVLDelete_C) then
+    InstallGlobalFunction(DS_AVLDelete, DS_AVLDelete_C);
 else
-    InstallGlobalFunction(AVLDelete, AVLDelete_GAP);
+    InstallGlobalFunction(DS_AVLDelete, DS_AVLDelete_GAP);
 fi;
 
-AVLIndexDelete_GAP := function(tree,index)
+DS_AVLIndexDelete_GAP := function(tree,index)
   # Parameters: tree, index
   #  index is the index of the element to be deleted, must be between 1 and
   #          tree![3] inclusively
-  #  tree is a AVL
+  #  tree is a DS_AVL
   # returns fail if index is out of range, otherwise the deleted key;
   local p, path, nodes, n, offset, c, m, l, r, x;
 
@@ -1025,10 +1025,10 @@ AVLIndexDelete_GAP := function(tree,index)
   fi;
   if tree![3] = 1 then
     # index must be equal to 1
-    x := AVLData(tree,tree![6]);
+    x := DS_AVLData(tree,tree![6]);
     tree![3] := 0;
     tree![6] := 0;
-    AVLFreeNode(tree,p);
+    DS_AVLFreeNode(tree,p);
     return x;
   fi;
 
@@ -1043,22 +1043,22 @@ AVLIndexDelete_GAP := function(tree,index)
   repeat
 
     # what is the next step?
-    if index = offset+AVLRank(tree,p) then
+    if index = offset+DS_AVLRank(tree,p) then
       c := 0;   # we found our node!
-      x := AVLData(tree,p);
-    elif index < offset+AVLRank(tree,p) then
+      x := DS_AVLData(tree,p);
+    elif index < offset+DS_AVLRank(tree,p) then
       c := -1;  # we have to go left
     else
       c := +1;  # we have to go right
     fi;
 
     if c <> 0 then  # only if data not found!
-      if c < 0 then       # data < AVLData(tree,p)
-        AVLSetRank(tree,p,AVLRank(tree,p) - 1);
-        p := AVLLeft(tree,p);
-      elif c > 0 then     # data > AVLData(tree,p)
-        offset := offset + AVLRank(tree,p);
-        p := AVLRight(tree,p);
+      if c < 0 then       # data < DS_AVLData(tree,p)
+        DS_AVLSetRank(tree,p,DS_AVLRank(tree,p) - 1);
+        p := DS_AVLLeft(tree,p);
+      elif c > 0 then     # data > DS_AVLData(tree,p)
+        offset := offset + DS_AVLRank(tree,p);
+        p := DS_AVLRight(tree,p);
       fi;
       Add(nodes,p);
       n := n + 1;
@@ -1072,44 +1072,44 @@ AVLIndexDelete_GAP := function(tree,index)
 
   # now we have to search a neighbour, we modify "nodes" and "path" but not n!
   m := n;
-  if AVLBalFactor(tree,p) < 0 then   # search to the left
-    l := AVLLeft(tree,p);   # must be a node!
-    AVLSetRank(tree,p,AVLRank(tree,p) - 1);
+  if DS_AVLBalFactor(tree,p) < 0 then   # search to the left
+    l := DS_AVLLeft(tree,p);   # must be a node!
+    DS_AVLSetRank(tree,p,DS_AVLRank(tree,p) - 1);
     # we will delete in left subtree!
     Add(nodes,l);
     m := m + 1;
     Add(path,-1);
-    while AVLRight(tree,l) <> 0 do
-      l := AVLRight(tree,l);
+    while DS_AVLRight(tree,l) <> 0 do
+      l := DS_AVLRight(tree,l);
       Add(nodes,l);
       m := m + 1;
       Add(path,1);
     od;
     c := -1;       # we got predecessor
-  elif AVLBalFactor(tree,p) > 0 then    # search to the right
-    l := AVLRight(tree,p);  # must be a node!
+  elif DS_AVLBalFactor(tree,p) > 0 then    # search to the right
+    l := DS_AVLRight(tree,p);  # must be a node!
     Add(nodes,l);
     m := m + 1;
     Add(path,1);
-    while AVLLeft(tree,l) <> 0 do
-      AVLSetRank(tree,l,AVLRank(tree,l) - 1);
+    while DS_AVLLeft(tree,l) <> 0 do
+      DS_AVLSetRank(tree,l,DS_AVLRank(tree,l) - 1);
       # we will delete in left subtree!
-      l := AVLLeft(tree,l);
+      l := DS_AVLLeft(tree,l);
       Add(nodes,l);
       m := m + 1;
       Add(path,-1);
     od;
     c := 1;        # we got successor
   else   # equal depths
-    if AVLLeft(tree,p) <> 0 then
-      l := AVLLeft(tree,p);
-      AVLSetRank(tree,p,AVLRank(tree,p) - 1);
+    if DS_AVLLeft(tree,p) <> 0 then
+      l := DS_AVLLeft(tree,p);
+      DS_AVLSetRank(tree,p,DS_AVLRank(tree,p) - 1);
       # we will delete in left subtree!
       Add(nodes,l);
       m := m + 1;
       Add(path,-1);
-      while AVLRight(tree,l) <> 0 do
-        l := AVLRight(tree,l);
+      while DS_AVLRight(tree,l) <> 0 do
+        l := DS_AVLRight(tree,l);
         Add(nodes,l);
         m := m + 1;
         Add(path,1);
@@ -1125,23 +1125,23 @@ AVLIndexDelete_GAP := function(tree,index)
   # "nodes" and "path" is updated, but n could be < m
 
   # Copy Data from l up to p: order is NOT modified
-  AVLSetData(tree,p,AVLData(tree,l));
+  DS_AVLSetData(tree,p,DS_AVLData(tree,l));
   # works for m = n, i.e. if p is end node
 
   # Delete node at l = nodes[m] by modifying nodes[m-1]:
   # Note: nodes[m] has maximal one subtree!
   if c <= 0 then
-    r := AVLLeft(tree,l);
+    r := DS_AVLLeft(tree,l);
   else  #  c > 0
-    r := AVLRight(tree,l);
+    r := DS_AVLRight(tree,l);
   fi;
   if path[m-1] < 0 then
-    AVLSetLeft(tree,nodes[m-1],r);
+    DS_AVLSetLeft(tree,nodes[m-1],r);
   else
-    AVLSetRight(tree,nodes[m-1],r);
+    DS_AVLSetRight(tree,nodes[m-1],r);
   fi;
   tree![3] := tree![3] - 1;
-  AVLFreeNode(tree,l);
+  DS_AVLFreeNode(tree,l);
 
   # modify balance factors:
   # the subtree nodes[m-1] has become shorter at its left (resp. right)
@@ -1151,20 +1151,20 @@ AVLIndexDelete_GAP := function(tree,index)
   # (we decrement m and work until the corresponding subtree has not shrunk)
   m := m - 1;  # start work HERE
   while m >= 1 do
-    if AVLBalFactor(tree,nodes[m]) = 0 then
-      AVLSetBalFactor(tree,nodes[m],-path[m]);  # we made path[m] shorter
+    if DS_AVLBalFactor(tree,nodes[m]) = 0 then
+      DS_AVLSetBalFactor(tree,nodes[m],-path[m]);  # we made path[m] shorter
       return x;
-    elif AVLBalFactor(tree,nodes[m]) = path[m] then
-      AVLSetBalFactor(tree,nodes[m],0);         # we made path[m] shorter
+    elif DS_AVLBalFactor(tree,nodes[m]) = path[m] then
+      DS_AVLSetBalFactor(tree,nodes[m],0);         # we made path[m] shorter
     else    # tree is out of balance
-      p := AVLRebalance(tree,nodes[m]);
+      p := DS_AVLRebalance(tree,nodes[m]);
       if m = 1 then
         tree![6] := p.newroot;
         return x;               # everything is done
       elif path[m-1] = -1 then
-        AVLSetLeft(tree,nodes[m-1],p.newroot);
+        DS_AVLSetLeft(tree,nodes[m-1],p.newroot);
       else
-        AVLSetRight(tree,nodes[m-1],p.newroot);
+        DS_AVLSetRight(tree,nodes[m-1],p.newroot);
       fi;
       if not p.shorter then return x; fi;   # nothing happens further up
     fi;
@@ -1172,14 +1172,14 @@ AVLIndexDelete_GAP := function(tree,index)
   od;
   return x;
 end;
-if IsBound(AVLIndexDelete_C) then
-    InstallGlobalFunction(AVLIndexDelete, AVLIndexDelete_C);
+if IsBound(DS_AVLIndexDelete_C) then
+    InstallGlobalFunction(DS_AVLIndexDelete, DS_AVLIndexDelete_C);
 else
-    InstallGlobalFunction(AVLIndexDelete, AVLIndexDelete_GAP);
+    InstallGlobalFunction(DS_AVLIndexDelete, DS_AVLIndexDelete_GAP);
 fi;
 
 
-AVLToList_GAP := function(tree)
+DS_AVLToList_GAP := function(tree)
   # walks recursively through the tree and builds a list, where every entry
   # belongs to a node in the order of the tree and each entry is a list,
   # containing the data as first entry, the depth in the tree as second
@@ -1191,25 +1191,25 @@ AVLToList_GAP := function(tree)
 
   DoRecursion := function(p,depth)
     # does the work
-    if AVLLeft(tree,p) <> 0 then
-      DoRecursion(AVLLeft(tree,p),depth+1);
+    if DS_AVLLeft(tree,p) <> 0 then
+      DoRecursion(DS_AVLLeft(tree,p),depth+1);
     fi;
-    Add(l,[AVLData(tree,p),depth,AVLBalFactor(tree,p)]);
-    if AVLRight(tree,p) <> 0 then
-      DoRecursion(AVLRight(tree,p),depth+1);
+    Add(l,[DS_AVLData(tree,p),depth,DS_AVLBalFactor(tree,p)]);
+    if DS_AVLRight(tree,p) <> 0 then
+      DoRecursion(DS_AVLRight(tree,p),depth+1);
     fi;
   end;
 
   DoRecursion(tree![6],1);
   return l;
 end;
-if IsBound(AVLToList_C) then
-    InstallGlobalFunction(AVLToList, AVLToList_C);
+if IsBound(DS_AVLToList_C) then
+    InstallGlobalFunction(DS_AVLToList, DS_AVLToList_C);
 else
-    InstallGlobalFunction(AVLToList, AVLToList_GAP);
+    InstallGlobalFunction(DS_AVLToList, DS_AVLToList_GAP);
 fi;
 
-BindGlobal( "AVLTest", function(tree)
+BindGlobal( "DS_AVLTest", function(tree)
   # walks recursively through the tree and tests its balancedness. Returns
   # the depth or the subtree where the tree is not balanced. Mainly for test
   # purposes. Returns tree if the NumberOfNodes is not correct.
@@ -1223,16 +1223,16 @@ BindGlobal( "AVLTest", function(tree)
     # and a list with the depth of the tree and the number of nodes in it.
     local ldepth, rdepth;
 
-    if AVLLeft(tree,p) <> 0 then
-      ldepth := DoRecursion(AVLLeft(tree,p));
+    if DS_AVLLeft(tree,p) <> 0 then
+      ldepth := DoRecursion(DS_AVLLeft(tree,p));
       if ldepth = false then
         return false;
       fi;
     else
       ldepth := [0,0];
     fi;
-    if AVLRight(tree,p) <> 0 then
-      rdepth := DoRecursion(AVLRight(tree,p));
+    if DS_AVLRight(tree,p) <> 0 then
+      rdepth := DoRecursion(DS_AVLRight(tree,p));
       if rdepth = false then
         return false;
       fi;
@@ -1240,8 +1240,8 @@ BindGlobal( "AVLTest", function(tree)
       rdepth := [0,0];
     fi;
     if AbsInt(rdepth[1]-ldepth[1] > 1) or
-       AVLBalFactor(tree,p) <> rdepth[1]-ldepth[1] or
-       AVLRank(tree,p) <> ldepth[2] + 1 then
+       DS_AVLBalFactor(tree,p) <> rdepth[1]-ldepth[1] or
+       DS_AVLRank(tree,p) <> ldepth[2] + 1 then
       error := p;
       return false;
     else
@@ -1267,9 +1267,9 @@ BindGlobal( "AVLTest", function(tree)
   fi;
 end);
 
-AVLFindIndex_GAP := function(tree,data)
+DS_AVLFindIndex_GAP := function(tree,data)
   # Parameters: tree, data
-  #  t is a AVL
+  #  t is a DS_AVL
   #  data is a data structure defined by the user
   # Searches in tree for a node equal to data, returns its index or fail
   # if not found.
@@ -1278,33 +1278,33 @@ AVLFindIndex_GAP := function(tree,data)
   p := tree![6];
   index := 0;
   while p >= 8 do
-    c := compare(data,AVLData(tree,p));
+    c := compare(data,DS_AVLData(tree,p));
     if c = 0 then
-      return index + AVLRank(tree,p);
-    elif c < 0 then    # data < AVLData(tree,p)
-      p := AVLLeft(tree,p);
-    else               # data > AVLData(tree,p)
-      index := index + AVLRank(tree,p);
-      p := AVLRight(tree,p);
+      return index + DS_AVLRank(tree,p);
+    elif c < 0 then    # data < DS_AVLData(tree,p)
+      p := DS_AVLLeft(tree,p);
+    else               # data > DS_AVLData(tree,p)
+      index := index + DS_AVLRank(tree,p);
+      p := DS_AVLRight(tree,p);
     fi;
   od;
   return fail;
 end ;
-if IsBound(AVLFindIndex_C) then
-    InstallGlobalFunction(AVLFindIndex, AVLFindIndex_C);
+if IsBound(DS_AVLFindIndex_C) then
+    InstallGlobalFunction(DS_AVLFindIndex, DS_AVLFindIndex_C);
 else
-    InstallGlobalFunction(AVLFindIndex, AVLFindIndex_GAP);
+    InstallGlobalFunction(DS_AVLFindIndex, DS_AVLFindIndex_GAP);
 fi;
 
 InstallOtherMethod( ELM_LIST, "for an avl tree and an index",
-  [ IsAVLTree and IsAVLTreeFlatRep, IsPosInt ],
-  AVLIndex );
+  [ IsDS_AVLTree and IsDS_AVLTreeFlatRep, IsPosInt ],
+  DS_AVLIndex );
 
 InstallOtherMethod( Position, "for an avl tree, an object, and an index",
-  [ IsAVLTree and IsAVLTreeFlatRep, IsObject, IsInt ],
+  [ IsDS_AVLTree and IsDS_AVLTreeFlatRep, IsObject, IsInt ],
   function( t, x, pos )
     local i,j;
-    i := AVLFindIndex(t,x);
+    i := DS_AVLFindIndex(t,x);
     if i = fail or i <= pos then
         return fail;
     else
@@ -1313,37 +1313,37 @@ InstallOtherMethod( Position, "for an avl tree, an object, and an index",
   end);
 
 InstallOtherMethod( Remove, "for an avl tree and an index",
-  [ IsAVLTree and IsAVLTreeFlatRep and IsMutable, IsPosInt ],
-  AVLIndexDelete );
+  [ IsDS_AVLTree and IsDS_AVLTreeFlatRep and IsMutable, IsPosInt ],
+  DS_AVLIndexDelete );
 
 InstallOtherMethod( Remove, "for an avl tree",
-  [ IsAVLTree and IsAVLTreeFlatRep and IsMutable ],
+  [ IsDS_AVLTree and IsDS_AVLTreeFlatRep and IsMutable ],
   function( t )
-    return AVLIndexDelete(t,t![3]);
+    return DS_AVLIndexDelete(t,t![3]);
   end );
 
 InstallOtherMethod( Length, "for an avl tree",
-  [ IsAVLTree and IsAVLTreeFlatRep ],
+  [ IsDS_AVLTree and IsDS_AVLTreeFlatRep ],
   function( t )
     return t![3];
   end );
 
 InstallOtherMethod( ADD_LIST, "for an avl tree and an object",
-  [ IsAVLTree and IsAVLTreeFlatRep and IsMutable, IsObject ],
+  [ IsDS_AVLTree and IsDS_AVLTreeFlatRep and IsMutable, IsObject ],
   function( t, x )
-    AVLIndexAdd(t,x,true,t![3]+1);
+    DS_AVLIndexAdd(t,x,true,t![3]+1);
   end );
 
 InstallOtherMethod( ADD_LIST, "for an avl tree, an object and a position",
-  [ IsAVLTree and IsAVLTreeFlatRep and IsMutable, IsObject, IsPosInt ],
+  [ IsDS_AVLTree and IsDS_AVLTreeFlatRep and IsMutable, IsObject, IsPosInt ],
   function( t, x, pos )
-    AVLIndexAdd(t,x,true,pos);
+    DS_AVLIndexAdd(t,x,true,pos);
   end );
 
 InstallOtherMethod( IN, "for an object and an avl tree",
-  [ IsObject, IsAVLTree and IsAVLTreeFlatRep ],
+  [ IsObject, IsDS_AVLTree and IsDS_AVLTreeFlatRep ],
   function( x, t )
-    return AVLFind(t,x) <> fail;
+    return DS_AVLFind(t,x) <> fail;
   end );
 
 

--- a/gap/cache.gd
+++ b/gap/cache.gd
@@ -18,23 +18,23 @@
 # Generic caching code:
 ########################
 
-BindGlobal( "CacheNodesFamily", NewFamily( "CacheNodesFamily" ) );
-BindGlobal( "CachesFamily", CollectionsFamily( CacheNodesFamily ) );
+BindGlobal( "DS_CacheNodesFamily", NewFamily( "DS_CacheNodesFamily" ) );
+BindGlobal( "DS_CachesFamily", CollectionsFamily( DS_CacheNodesFamily ) );
 
-DeclareCategory("IsCache", IsNonAtomicComponentObjectRep);
-DeclareRepresentation("IsLinkedListCacheRep", IsCache,
+DeclareCategory("IsDS_Cache", IsNonAtomicComponentObjectRep);
+DeclareRepresentation("IsDS_LinkedListCacheRep", IsDS_Cache,
   [ "head", "tail", "nrobs", "memory", "memorylimit" ]);
-DeclareCategory("IsCacheNode", IsNonAtomicComponentObjectRep);
-DeclareRepresentation("IsLinkedListCacheNodeRep", IsCacheNode,
+DeclareCategory("IsDS_CacheNode", IsNonAtomicComponentObjectRep);
+DeclareRepresentation("IsDS_LinkedListCacheNodeRep", IsDS_CacheNode,
   [ "next", "prev", "ob", "mem" ] );
-BindGlobal( "LinkedListCacheNodeType",
-  NewType( CacheNodesFamily, IsLinkedListCacheNodeRep and IsMutable) );
+BindGlobal( "DS_LinkedListCacheNodeType",
+  NewType( DS_CacheNodesFamily, IsDS_LinkedListCacheNodeRep and IsMutable) );
 
-DeclareOperation("LinkedListCache", [IsInt]);
-DeclareOperation("ClearCache", [IsCache]);
-DeclareGlobalFunction("CacheObject");
-DeclareGlobalFunction("EnforceCachelimit");
-DeclareGlobalFunction("UseCacheObject");
+DeclareOperation("DS_LinkedListCache", [IsInt]);
+DeclareOperation("DS_ClearCache", [IsDS_Cache]);
+DeclareGlobalFunction("DS_CacheObject");
+DeclareGlobalFunction("DS_EnforceCachelimit");
+DeclareGlobalFunction("DS_UseCacheObject");
 
 
 ##

--- a/gap/cache.gi
+++ b/gap/cache.gi
@@ -18,24 +18,24 @@
 # Generic caching code:
 ########################
 
-InstallMethod( LinkedListCache, "for an integer", [ IsInt ],
+InstallMethod( DS_LinkedListCache, "for an integer", [ IsInt ],
   function(memorylimit)
     local c;
     c := rec(head := fail, tail := fail, nrobs := 0,
              memory := 0, memorylimit := memorylimit);
-    Objectify(NewType(CachesFamily,IsLinkedListCacheRep and IsMutable),c);
+    Objectify(NewType(DS_CachesFamily,IsDS_LinkedListCacheRep and IsMutable),c);
     return c;
 end );
 
 InstallMethod( ViewObj, "for a linked list cache object",
-  [ IsCache and IsLinkedListCacheRep ],
+  [ IsDS_Cache and IsDS_LinkedListCacheRep ],
   function(c)
     Print("<linked list cache with ",c!.nrobs," objects using ",
           c!.memory," <= ",c!.memorylimit," bytes>");
   end );
 
 InstallMethod( Display, "for a linked list cache object",
-  [ IsCache and IsLinkedListCacheRep ],
+  [ IsDS_Cache and IsDS_LinkedListCacheRep ],
   function(c)
     local cn,i;
     cn := c!.head;
@@ -52,8 +52,8 @@ InstallMethod( Display, "for a linked list cache object",
     Print(">\n");
   end );
 
-InstallMethod( ClearCache, "for a linked list cache object",
-  [ IsCache and IsLinkedListCacheRep ],
+InstallMethod( DS_ClearCache, "for a linked list cache object",
+  [ IsDS_Cache and IsDS_LinkedListCacheRep ],
   function(c)
     c!.head := fail;
     c!.tail := fail;
@@ -61,11 +61,11 @@ InstallMethod( ClearCache, "for a linked list cache object",
     c!.memory := 0;
   end );
 
-InstallGlobalFunction( CacheObject,
+InstallGlobalFunction( DS_CacheObject,
   function( c, ob, mem )
     local r;
     r := rec( ob := ob, next := c!.head, prev := fail, mem := mem );
-    Objectify( LinkedListCacheNodeType, r );
+    Objectify( DS_LinkedListCacheNodeType, r );
     c!.head := r;
     c!.memory := c!.memory + mem;
     if c!.tail = fail then
@@ -74,11 +74,11 @@ InstallGlobalFunction( CacheObject,
         r!.next!.prev := r;
     fi;
     c!.nrobs := c!.nrobs + 1;
-    EnforceCachelimit(c);
+    DS_EnforceCachelimit(c);
     return r;
   end );
 
-InstallGlobalFunction( EnforceCachelimit,
+InstallGlobalFunction( DS_EnforceCachelimit,
   function(c)
     local s;
     # Delete something if memory usage too high:
@@ -98,19 +98,19 @@ InstallGlobalFunction( EnforceCachelimit,
 
 
 InstallMethod( ViewObj, "for a linked list cache node",
-  [ IsCacheNode and IsLinkedListCacheNodeRep ],
+  [ IsDS_CacheNode and IsDS_LinkedListCacheNodeRep ],
   function( cn )
     Print("<linked list cache node ob=");
     ViewObj(cn!.ob);
     Print(" mem=",cn!.mem,">");
   end );
 
-InstallGlobalFunction( UseCacheObject,
+InstallGlobalFunction( DS_UseCacheObject,
   function( c, r )
     local s;
     if r!.prev = false then
         # the object is no longer in the cache, we cache it again:
-        # note that we cannot use CacheObject, because we want to retain
+        # note that we cannot use DS_CacheObject, because we want to retain
         # the cache node r itself!
         r!.prev := fail;
         r!.next := c!.head;
@@ -122,7 +122,7 @@ InstallGlobalFunction( UseCacheObject,
             r!.next!.prev := r;
         fi;
         c!.nrobs := c!.nrobs + 1;
-        EnforceCachelimit(c);
+        DS_EnforceCachelimit(c);
         return;
     fi;
     if r!.prev = fail then return; fi;   # nothing to do

--- a/gap/hash.gd
+++ b/gap/hash.gd
@@ -18,52 +18,53 @@
 # Generic hashing code:
 ########################
 
-DeclareGlobalFunction( "InitHT" );
-DeclareGlobalFunction( "NewHT" );
-DeclareGlobalFunction( "AddHT" );
-DeclareGlobalFunction( "ValueHT" );
-DeclareGlobalFunction( "GrowHT" );
+DeclareGlobalFunction( "InitDS_HT" );
+DeclareGlobalFunction( "NewDS_HT" );
+DeclareGlobalFunction( "AddDS_HT" );
+DeclareGlobalFunction( "ValueDS_HT" );
+DeclareGlobalFunction( "GrowDS_HT" );
 
-BindGlobal( "HashTabFamily", NewFamily("HashTabFamily") );
-DeclareCategory( "IsHashTab", IsNonAtomicComponentObjectRep and
+BindGlobal( "DS_HashTabFamily", NewFamily("DS_HashTabFamily") );
+DeclareCategory( "IsDS_HashTab", IsNonAtomicComponentObjectRep and
                               IsComponentObjectRep);
-DeclareRepresentation( "IsHashTabRep", IsHashTab, [] );
-DeclareRepresentation( "IsTreeHashTabRep", IsHashTab, [] );
-BindGlobal( "HashTabType", NewType(HashTabFamily,IsHashTabRep and IsMutable) );
-BindGlobal( "TreeHashTabType",
-  NewType(HashTabFamily,IsTreeHashTabRep and IsMutable) );
+DeclareRepresentation( "IsDS_HashTabRep", IsDS_HashTab, [] );
+DeclareRepresentation( "IsDS_TreeHashTabRep", IsDS_HashTab, [] );
+BindGlobal( "DS_HashTabType", NewType(DS_HashTabFamily,IsDS_HashTabRep and IsMutable) );
+BindGlobal( "DS_TreeHashTabType",
+  NewType(DS_HashTabFamily,IsDS_TreeHashTabRep and IsMutable) );
 
-DeclareOperation( "HTCreate", [ IsObject, IsRecord ] );
-DeclareOperation( "HTCreate", [ IsObject ] );
-DeclareOperation( "HTAdd", [ IsHashTab, IsObject, IsObject ] );
-DeclareOperation( "HTValue", [ IsHashTab, IsObject ] );
-DeclareOperation( "HTDelete", [ IsHashTab, IsObject ] );
-DeclareOperation( "HTUpdate", [ IsHashTab, IsObject, IsObject ] );
-DeclareOperation( "HTGrow", [ IsHashTab, IsObject ] );
+DeclareOperation( "DS_HTCreate", [ IsObject, IsRecord ] );
+DeclareOperation( "DS_HTCreate", [ IsObject ] );
+DeclareOperation( "DS_HTAdd", [ IsDS_HashTab, IsObject, IsObject ] );
+DeclareOperation( "DS_HTValue", [ IsDS_HashTab, IsObject ] );
+DeclareOperation( "DS_HTDelete", [ IsDS_HashTab, IsObject ] );
+DeclareOperation( "DS_HTUpdate", [ IsDS_HashTab, IsObject, IsObject ] );
+DeclareOperation( "DS_HTGrow", [ IsDS_HashTab, IsObject ] );
 
 
 #########################################################################
 # Infrastructure for choosing hash functions looking at example objects:
 #########################################################################
 
+# Duplicate in ORB, but probably fine to leave this name
 DeclareOperation( "ChooseHashFunction", [IsObject, IsInt] );
 
-DeclareGlobalFunction( "ORB_HashFunctionReturn1" );
-DeclareGlobalFunction( "ORB_HashFunctionForShortGF2Vectors" );
-DeclareGlobalFunction( "ORB_HashFunctionForShort8BitVectors" );
-DeclareGlobalFunction( "ORB_HashFunctionForGF2Vectors" );
-DeclareGlobalFunction( "ORB_HashFunctionFor8BitVectors" );
-DeclareGlobalFunction( "ORB_HashFunctionForCompressedMats" );
-DeclareGlobalFunction( "ORB_HashFunctionForIntegers" );
-DeclareGlobalFunction( "ORB_HashFunctionForMemory" );
-DeclareGlobalFunction( "ORB_HashFunctionForPermutations" );
-DeclareGlobalFunction( "ORB_HashFunctionForIntList" );
-DeclareGlobalFunction( "ORB_HashFunctionForNBitsPcWord" );
-DeclareGlobalFunction( "ORB_HashFunctionModWrapper" );
-DeclareGlobalFunction( "ORB_HashFunctionForMatList" );
-DeclareGlobalFunction( "ORB_HashFunctionForPlainFlatList" );
-DeclareGlobalFunction( "ORB_HashFunctionForTransformations" );
-DeclareGlobalFunction( "MakeHashFunctionForPlainFlatList" );
+DeclareGlobalFunction( "DS_HashFunctionReturn1" );
+DeclareGlobalFunction( "DS_HashFunctionForShortGF2Vectors" );
+DeclareGlobalFunction( "DS_HashFunctionForShort8BitVectors" );
+DeclareGlobalFunction( "DS_HashFunctionForGF2Vectors" );
+DeclareGlobalFunction( "DS_HashFunctionFor8BitVectors" );
+DeclareGlobalFunction( "DS_HashFunctionForCompressedMats" );
+DeclareGlobalFunction( "DS_HashFunctionForIntegers" );
+DeclareGlobalFunction( "DS_HashFunctionForMemory" );
+DeclareGlobalFunction( "DS_HashFunctionForPermutations" );
+DeclareGlobalFunction( "DS_HashFunctionForIntList" );
+DeclareGlobalFunction( "DS_HashFunctionForNBitsPcWord" );
+DeclareGlobalFunction( "DS_HashFunctionModWrapper" );
+DeclareGlobalFunction( "DS_HashFunctionForMatList" );
+DeclareGlobalFunction( "DS_HashFunctionForPlainFlatList" );
+DeclareGlobalFunction( "DS_HashFunctionForTransformations" );
+DeclareGlobalFunction( "DS_MakeHashFunctionForPlainFlatList" );
 
 ##
 ##  This program is free software: you can redistribute it and/or modify

--- a/src/avltree.c
+++ b/src/avltree.c
@@ -2,7 +2,7 @@
  * Datastructures: GAP package providing common datastructures.
  * Licensed under the GPL 2 or later.
  *
- * This file contains an AVL tree implementation,
+ * This file contains an DS_AVL tree implementation,
  *  Copyright (C) 2009-2013  Max Neunhoeffer
  */
 
@@ -11,14 +11,14 @@
 /* This file corresponds to orb/gap/avltree.gi, it imlements some of
  * its functionality on the C level for better performance. */
 
-Obj AVLTreeType;    /* Imported from the library to be able to check type */
-Obj AVLTreeTypeMutable;
+Obj DS_AVLTreeType;    /* Imported from the library to be able to check type */
+Obj DS_AVLTreeTypeMutable;
                     /* Imported from the library to be able to check type */
-Obj AVLTree;        /* Constructor function imported from the library */
+Obj DS_AVLTree;        /* Constructor function imported from the library */
 
 /* Conventions:
  *
- * A balanced binary tree (AVLTree) is a positional object having the
+ * A balanced binary tree (DS_AVLTree) is a positional object having the
  * following entries:
  *   ![1]     len: last used entry, never shrinks), always = 3 mod 4
  *   ![2]     free: index of first freed entry, if 0, none free
@@ -43,7 +43,7 @@ Obj AVLTree;        /* Constructor function imported from the library */
 /* Note that we have to check the arguments for functions that are called
  * by user programs since we do not go through method selection! */
 
-Obj AVLCmp_C(Obj self, Obj a, Obj b)
+Obj DS_AVLCmp_C(Obj self, Obj a, Obj b)
 /* A very fast three-way comparison function. */
 {
     if (EQ(a,b)) return INTOBJ_INT(0);
@@ -55,66 +55,66 @@ Obj AVLCmp_C(Obj self, Obj a, Obj b)
  * We always know that these positions are properly initialized! */
 
 /* Last used entry, never shrinks, always = 3 mod 4: */
-#define AVLLen(t) INT_INTOBJ(ELM_PLIST(t,1))
-#define SetAVLLen(t,i) SET_ELM_PLIST(t,1,INTOBJ_INT(i))
+#define DS_AVLLen(t) INT_INTOBJ(ELM_PLIST(t,1))
+#define SetDS_AVLLen(t,i) SET_ELM_PLIST(t,1,INTOBJ_INT(i))
 /* Index of first freed entry, if 0, none free: */
-#define AVLFree(t) INT_INTOBJ(ELM_PLIST(t,2))
-#define AVLFreeObj(t) ELM_PLIST(t,2)
-#define SetAVLFree(t,i) SET_ELM_PLIST(t,2,INTOBJ_INT(i))
-#define SetAVLFreeObj(t,i) SET_ELM_PLIST(t,2,i)
+#define DS_AVLFree(t) INT_INTOBJ(ELM_PLIST(t,2))
+#define DS_AVLFreeObj(t) ELM_PLIST(t,2)
+#define SetDS_AVLFree(t,i) SET_ELM_PLIST(t,2,INTOBJ_INT(i))
+#define SetDS_AVLFreeObj(t,i) SET_ELM_PLIST(t,2,i)
 /* Number of nodes currently in the tree: */
-#define AVLNodes(t) INT_INTOBJ(ELM_PLIST(t,3))
-#define SetAVLNodes(t,i) SET_ELM_PLIST(t,3,INTOBJ_INT(i))
+#define DS_AVLNodes(t) INT_INTOBJ(ELM_PLIST(t,3))
+#define SetDS_AVLNodes(t,i) SET_ELM_PLIST(t,3,INTOBJ_INT(i))
 /* Highest allocated index, always = 3 mod 4: */
-#define AVLAlloc(t) INT_INTOBJ(ELM_PLIST(t,4))
-#define SetAVLAlloc(t,i) SET_ELM_PLIST(t,4,INTOBJ_INT(i))
+#define DS_AVLAlloc(t) INT_INTOBJ(ELM_PLIST(t,4))
+#define SetDS_AVLAlloc(t,i) SET_ELM_PLIST(t,4,INTOBJ_INT(i))
 /* Three-way-comparison function: */
-#define AVL3Comp(t) ELM_PLIST(t,5)
-#define SetAVL3Comp(t,f) SET_ELM_PLIST(t,5,f);CHANGED_BAG(t)
+#define DS_AVL3Comp(t) ELM_PLIST(t,5)
+#define SetDS_AVL3Comp(t,f) SET_ELM_PLIST(t,5,f);CHANGED_BAG(t)
 /* Reference to the top node: */
-#define AVLTop(t) INT_INTOBJ(ELM_PLIST(t,6))
-#define SetAVLTop(t,i) SET_ELM_PLIST(t,6,INTOBJ_INT(i))
+#define DS_AVLTop(t) INT_INTOBJ(ELM_PLIST(t,6))
+#define SetDS_AVLTop(t,i) SET_ELM_PLIST(t,6,INTOBJ_INT(i))
 /* Reference to the value plist: */
-#define AVLValues(t) ELM_PLIST(t,7)
-#define SetAVLValues(t,l) SET_ELM_PLIST(t,7,l);CHANGED_BAG(t)
+#define DS_AVLValues(t) ELM_PLIST(t,7)
+#define SetDS_AVLValues(t,l) SET_ELM_PLIST(t,7,l);CHANGED_BAG(t)
 
-#define AVLmask ((unsigned long)(3L))
-#define AVLmask2 ((unsigned long)(-4L))
+#define DS_AVLmask ((unsigned long)(3L))
+#define DS_AVLmask2 ((unsigned long)(-4L))
 /* Use the following only if you know that the tree object is long enough and
  * something is bound to position i! */
-#define AVLData(t,i) ELM_PLIST(t,i)
-#define SetAVLData(t,i,d) SET_ELM_PLIST(t,i,d); CHANGED_BAG(t)
-#define AVLLeft(t,i) (INT_INTOBJ(ELM_PLIST(t,i+1)) & AVLmask2)
-#define SetAVLLeft(t,i,n) SET_ELM_PLIST(t,i+1, \
-  INTOBJ_INT( (INT_INTOBJ(ELM_PLIST(t,i+1)) & AVLmask) + n ))
-#define AVLRight(t,i) INT_INTOBJ(ELM_PLIST(t,i+2))
-#define SetAVLRight(t,i,n) SET_ELM_PLIST(t,i+2,INTOBJ_INT(n))
-#define AVLRank(t,i) INT_INTOBJ(ELM_PLIST(t,i+3))
-#define SetAVLRank(t,i,r) SET_ELM_PLIST(t,i+3,INTOBJ_INT(r))
-#define AVLBalFactor(t,i) (INT_INTOBJ(ELM_PLIST(t,i+1)) & AVLmask)
-#define SetAVLBalFactor(t,i,b) SET_ELM_PLIST(t,i+1, \
-  INTOBJ_INT( (INT_INTOBJ(ELM_PLIST(t,i+1)) & AVLmask2) + b ))
+#define DS_AVLData(t,i) ELM_PLIST(t,i)
+#define SetDS_AVLData(t,i,d) SET_ELM_PLIST(t,i,d); CHANGED_BAG(t)
+#define DS_AVLLeft(t,i) (INT_INTOBJ(ELM_PLIST(t,i+1)) & DS_AVLmask2)
+#define SetDS_AVLLeft(t,i,n) SET_ELM_PLIST(t,i+1, \
+  INTOBJ_INT( (INT_INTOBJ(ELM_PLIST(t,i+1)) & DS_AVLmask) + n ))
+#define DS_AVLRight(t,i) INT_INTOBJ(ELM_PLIST(t,i+2))
+#define SetDS_AVLRight(t,i,n) SET_ELM_PLIST(t,i+2,INTOBJ_INT(n))
+#define DS_AVLRank(t,i) INT_INTOBJ(ELM_PLIST(t,i+3))
+#define SetDS_AVLRank(t,i,r) SET_ELM_PLIST(t,i+3,INTOBJ_INT(r))
+#define DS_AVLBalFactor(t,i) (INT_INTOBJ(ELM_PLIST(t,i+1)) & DS_AVLmask)
+#define SetDS_AVLBalFactor(t,i,b) SET_ELM_PLIST(t,i+1, \
+  INTOBJ_INT( (INT_INTOBJ(ELM_PLIST(t,i+1)) & DS_AVLmask2) + b ))
 
-Int AVLNewNode( Obj t )
+Int DS_AVLNewNode( Obj t )
 {
     Int n,a;
-    n = AVLFree(t);
+    n = DS_AVLFree(t);
     if (n > 0) {
-        SetAVLFreeObj(t,ELM_PLIST(t,n));
+        SetDS_AVLFreeObj(t,ELM_PLIST(t,n));
     } else {
-        n = AVLLen(t);
-        a = AVLAlloc(t);
+        n = DS_AVLLen(t);
+        a = DS_AVLAlloc(t);
         if (n < a) {
             /* There is already enough allocated! */
-            SetAVLLen(t,n+4);
+            SetDS_AVLLen(t,n+4);
             n++;
         } else {
             /* We have to allocate new space! */
             n++;
             a = a*2 + 1;   /* Retain congruent 3 mod 4 */
-            SetAVLAlloc(t,a);
+            SetDS_AVLAlloc(t,a);
             ResizeBag(t,(a+1)*sizeof(Obj));
-            SetAVLLen(t,n+3);
+            SetDS_AVLLen(t,n+3);
         }
     }
     SET_ELM_PLIST(t,n,INTOBJ_INT(0));
@@ -124,22 +124,22 @@ Int AVLNewNode( Obj t )
     return n;
 }
 
-Obj AVLNewNode_C( Obj self, Obj t )
+Obj DS_AVLNewNode_C( Obj self, Obj t )
 {
-    if ( TNUM_OBJ(t) != T_POSOBJ || TYPE_POSOBJ(t) != AVLTreeTypeMutable) {
-        ErrorQuit( "Usage: AVLNewNode(avltree)", 0L, 0L );
+    if ( TNUM_OBJ(t) != T_POSOBJ || TYPE_POSOBJ(t) != DS_AVLTreeTypeMutable) {
+        ErrorQuit( "Usage: DS_AVLNewNode(avltree)", 0L, 0L );
         return 0L;
     }
-    return INTOBJ_INT(AVLNewNode(t));
+    return INTOBJ_INT(DS_AVLNewNode(t));
 }
 
- Obj AVLFreeNode( Obj t, Int n )
+ Obj DS_AVLFreeNode( Obj t, Int n )
 {
     Obj v,o;
-    SET_ELM_PLIST(t,n,AVLFreeObj(t));
-    SetAVLFree(t,n);
+    SET_ELM_PLIST(t,n,DS_AVLFreeObj(t));
+    SetDS_AVLFree(t,n);
     n /= 4;
-    v = AVLValues(t);
+    v = DS_AVLValues(t);
     if (v != Fail && ISB_LIST(v,n)) {
         o = ELM_PLIST(v,n);
         UNB_LIST(v,n);
@@ -148,192 +148,192 @@ Obj AVLNewNode_C( Obj self, Obj t )
     return True;
 }
 
-Obj AVLFreeNode_C( Obj self, Obj t, Obj n)
+Obj DS_AVLFreeNode_C( Obj self, Obj t, Obj n)
 {
     if (!IS_INTOBJ(n) ||
-        TNUM_OBJ(t) != T_POSOBJ || TYPE_POSOBJ(t) != AVLTreeTypeMutable) {
-        ErrorQuit( "Usage: AVLFreeNode(avltree,integer)", 0L, 0L );
+        TNUM_OBJ(t) != T_POSOBJ || TYPE_POSOBJ(t) != DS_AVLTreeTypeMutable) {
+        ErrorQuit( "Usage: DS_AVLFreeNode(avltree,integer)", 0L, 0L );
         return 0L;
     }
-    return AVLFreeNode(t,INT_INTOBJ(n));
+    return DS_AVLFreeNode(t,INT_INTOBJ(n));
 }
 
-Obj AVLValue( Obj t, Int n )
+Obj DS_AVLValue( Obj t, Int n )
 {
-    Obj vals = AVLValues(t);
+    Obj vals = DS_AVLValues(t);
     if (vals == Fail) return True;
     n /= 4;
     if (!ISB_LIST(vals,n)) return True;
     return ELM_LIST(vals,n);
 }
 
-void SetAVLValue( Obj t, Int n, Obj v )
+void SetDS_AVLValue( Obj t, Int n, Obj v )
 {
-    Obj vals = AVLValues(t);
+    Obj vals = DS_AVLValues(t);
     n /= 4;
     if (vals == Fail || !IS_LIST(vals)) {
         vals = NEW_PLIST(T_PLIST, n);
-        SetAVLValues(t,vals);
+        SetDS_AVLValues(t,vals);
     }
     ASS_LIST(vals,n,v);
 }
 
-Int AVLFind( Obj t, Obj d )
+Int DS_AVLFind( Obj t, Obj d )
 {
     Obj compare,c;
     Int p;
 
-    compare = AVL3Comp(t);
-    p = AVLTop(t);
+    compare = DS_AVL3Comp(t);
+    p = DS_AVLTop(t);
     while (p >= 8) {
-        c = CALL_2ARGS(compare,d,AVLData(t,p));
+        c = CALL_2ARGS(compare,d,DS_AVLData(t,p));
         if (c == INTOBJ_INT(0))
             return p;
-        else if (INT_INTOBJ(c) < 0)   /* d < AVLData(t,p) */
-            p = AVLLeft(t,p);
-        else                          /* d > AVLData(t,p) */
-            p = AVLRight(t,p);
+        else if (INT_INTOBJ(c) < 0)   /* d < DS_AVLData(t,p) */
+            p = DS_AVLLeft(t,p);
+        else                          /* d > DS_AVLData(t,p) */
+            p = DS_AVLRight(t,p);
     }
     return 0;
 }
 
- Obj AVLFind_C( Obj self, Obj t, Obj d )
+ Obj DS_AVLFind_C( Obj self, Obj t, Obj d )
 {
     Int tmp;
     if (TNUM_OBJ(t) != T_POSOBJ ||
-        (TYPE_POSOBJ(t) != AVLTreeType &&
-         TYPE_POSOBJ(t) != AVLTreeTypeMutable)) {
-        ErrorQuit( "Usage: AVLFind(avltree, object)", 0L, 0L );
+        (TYPE_POSOBJ(t) != DS_AVLTreeType &&
+         TYPE_POSOBJ(t) != DS_AVLTreeTypeMutable)) {
+        ErrorQuit( "Usage: DS_AVLFind(avltree, object)", 0L, 0L );
         return 0L;
     }
-    tmp = AVLFind(t,d);
+    tmp = DS_AVLFind(t,d);
     if (tmp == 0)
         return Fail;
     else
         return INTOBJ_INT(tmp);
 }
 
- Int AVLFindIndex( Obj t, Obj d )
+ Int DS_AVLFindIndex( Obj t, Obj d )
 {
     Obj compare,c;
     Int p;
     Int offset;
 
-    compare = AVL3Comp(t);
-    p = AVLTop(t);
+    compare = DS_AVL3Comp(t);
+    p = DS_AVLTop(t);
     offset = 0;
     while (p >= 8) {
-        c = CALL_2ARGS(compare,d,AVLData(t,p));
+        c = CALL_2ARGS(compare,d,DS_AVLData(t,p));
         if (c == INTOBJ_INT(0))
-            return offset + AVLRank(t,p);
-        else if (INT_INTOBJ(c) < 0)   /* d < AVLData(t,p) */
-            p = AVLLeft(t,p);
-        else {                         /* d > AVLData(t,p) */
-            offset += AVLRank(t,p);
-            p = AVLRight(t,p);
+            return offset + DS_AVLRank(t,p);
+        else if (INT_INTOBJ(c) < 0)   /* d < DS_AVLData(t,p) */
+            p = DS_AVLLeft(t,p);
+        else {                         /* d > DS_AVLData(t,p) */
+            offset += DS_AVLRank(t,p);
+            p = DS_AVLRight(t,p);
         }
     }
     return 0;
 }
 
- Obj AVLFindIndex_C( Obj self, Obj t, Obj d )
+ Obj DS_AVLFindIndex_C( Obj self, Obj t, Obj d )
 {
     Int tmp;
     if (TNUM_OBJ(t) != T_POSOBJ ||
-        (TYPE_POSOBJ(t) != AVLTreeType &&
-         TYPE_POSOBJ(t) != AVLTreeTypeMutable)) {
-        ErrorQuit( "Usage: AVLFindIndex(avltree, object)", 0L, 0L );
+        (TYPE_POSOBJ(t) != DS_AVLTreeType &&
+         TYPE_POSOBJ(t) != DS_AVLTreeTypeMutable)) {
+        ErrorQuit( "Usage: DS_AVLFindIndex(avltree, object)", 0L, 0L );
         return 0L;
     }
-    tmp = AVLFindIndex(t,d);
+    tmp = DS_AVLFindIndex(t,d);
     if (tmp == 0)
         return Fail;
     else
         return INTOBJ_INT(tmp);
 }
 
- Obj AVLLookup_C( Obj self, Obj t, Obj d )
+ Obj DS_AVLLookup_C( Obj self, Obj t, Obj d )
 {
     Int p;
     if (TNUM_OBJ(t) != T_POSOBJ ||
-        (TYPE_POSOBJ(t) != AVLTreeType &&
-         TYPE_POSOBJ(t) != AVLTreeTypeMutable)) {
-        ErrorQuit( "Usage: AVLLookup(avltree, object)", 0L, 0L );
+        (TYPE_POSOBJ(t) != DS_AVLTreeType &&
+         TYPE_POSOBJ(t) != DS_AVLTreeTypeMutable)) {
+        ErrorQuit( "Usage: DS_AVLLookup(avltree, object)", 0L, 0L );
         return 0L;
     }
-    p = AVLFind(t,d);
+    p = DS_AVLFind(t,d);
     if (p == 0) return Fail;
-    return AVLValue(t,p);
+    return DS_AVLValue(t,p);
 }
 
- Int AVLIndex( Obj t, Int i )
+ Int DS_AVLIndex( Obj t, Int i )
 {
     Int p,offset,r;
 
-    if (i < 1 || i > AVLNodes(t)) return 0;
-    p = AVLTop(t);
+    if (i < 1 || i > DS_AVLNodes(t)) return 0;
+    p = DS_AVLTop(t);
     offset = 0;
     while (1) {   /* will be left by return */
-        r = offset + AVLRank(t,p);
+        r = offset + DS_AVLRank(t,p);
         if (i < r)   /* go left: */
-            p = AVLLeft(t,p);
+            p = DS_AVLLeft(t,p);
         else if (i == r)   /* found! */
             return p;
         else {    /* go right: */
             offset = r;
-            p = AVLRight(t,p);
+            p = DS_AVLRight(t,p);
         }
     }
 }
 
- Obj AVLIndex_C( Obj self, Obj t, Obj i )
+ Obj DS_AVLIndex_C( Obj self, Obj t, Obj i )
 {
     Int p;
     if (!IS_INTOBJ(i) ||
         TNUM_OBJ(t) != T_POSOBJ ||
-        (TYPE_POSOBJ(t) != AVLTreeType &&
-         TYPE_POSOBJ(t) != AVLTreeTypeMutable)) {
-        ErrorQuit( "Usage: AVLIndex(avltree, integer)", 0L, 0L );
+        (TYPE_POSOBJ(t) != DS_AVLTreeType &&
+         TYPE_POSOBJ(t) != DS_AVLTreeTypeMutable)) {
+        ErrorQuit( "Usage: DS_AVLIndex(avltree, integer)", 0L, 0L );
         return 0L;
     }
-    p = AVLIndex( t, INT_INTOBJ(i) );
+    p = DS_AVLIndex( t, INT_INTOBJ(i) );
     if (p == 0)
         return Fail;
     else
-        return AVLData(t,p);
+        return DS_AVLData(t,p);
 }
 
- Obj AVLIndexFind_C( Obj self, Obj t, Obj i )
+ Obj DS_AVLIndexFind_C( Obj self, Obj t, Obj i )
 {
     Int p;
     if (!IS_INTOBJ(i) ||
         TNUM_OBJ(t) != T_POSOBJ ||
-        (TYPE_POSOBJ(t) != AVLTreeType &&
-         TYPE_POSOBJ(t) != AVLTreeTypeMutable)) {
-        ErrorQuit( "Usage: AVLIndexFind(avltree, integer)", 0L, 0L );
+        (TYPE_POSOBJ(t) != DS_AVLTreeType &&
+         TYPE_POSOBJ(t) != DS_AVLTreeTypeMutable)) {
+        ErrorQuit( "Usage: DS_AVLIndexFind(avltree, integer)", 0L, 0L );
         return 0L;
     }
-    p = AVLIndex( t, INT_INTOBJ(i) );
+    p = DS_AVLIndex( t, INT_INTOBJ(i) );
     if (p == 0)
         return Fail;
     else
         return INTOBJ_INT(p);
 }
 
- Obj AVLIndexLookup_C( Obj self, Obj t, Obj i )
+ Obj DS_AVLIndexLookup_C( Obj self, Obj t, Obj i )
 {
     Int p;
     Obj vals;
     if (!IS_INTOBJ(i) ||
         TNUM_OBJ(t) != T_POSOBJ ||
-        (TYPE_POSOBJ(t) != AVLTreeType &&
-         TYPE_POSOBJ(t) != AVLTreeTypeMutable)) {
-        ErrorQuit( "Usage: AVLIndexLookup(avltree, integer)", 0L, 0L );
+        (TYPE_POSOBJ(t) != DS_AVLTreeType &&
+         TYPE_POSOBJ(t) != DS_AVLTreeTypeMutable)) {
+        ErrorQuit( "Usage: DS_AVLIndexLookup(avltree, integer)", 0L, 0L );
         return 0L;
     }
-    p = AVLIndex(t,INT_INTOBJ(i));
+    p = DS_AVLIndex(t,INT_INTOBJ(i));
     if (p == 0) return Fail;
-    vals = AVLValues(t);
+    vals = DS_AVLValues(t);
     p /= 4;
     if (vals == Fail || !ISB_LIST(vals,p))
         return True;
@@ -341,7 +341,7 @@ Int AVLFind( Obj t, Obj d )
         return ELM_LIST(vals,p);
 }
 
- void AVLRebalance( Obj tree, Int q, Int *newroot, int *shrink )
+ void DS_AVLRebalance( Obj tree, Int q, Int *newroot, int *shrink )
 /* the tree starting at q has balanced subtrees but is out of balance:
    the depth of the deeper subtree is 2 bigger than the depth of the other
    tree. This function changes this situation following the procedure
@@ -353,31 +353,31 @@ Int AVLFind( Obj t, Obj d )
   Int p, l;
 
   *shrink = 1;   /* in nearly all cases this happens */
-  if (AVLBalFactor(tree,q) == 2)   /* was: < 0 */
-      p = AVLLeft(tree,q);
+  if (DS_AVLBalFactor(tree,q) == 2)   /* was: < 0 */
+      p = DS_AVLLeft(tree,q);
   else
-      p = AVLRight(tree,q);
-  if (AVLBalFactor(tree,p) == AVLBalFactor(tree,q)) {
+      p = DS_AVLRight(tree,q);
+  if (DS_AVLBalFactor(tree,p) == DS_AVLBalFactor(tree,q)) {
       /* we need a single rotation:
              q++             p=           q--          p=
             / \             / \          / \          / \
            a   p+    ==>   q=  c    OR  p-  c   ==>  a   q=
               / \         / \          / \              / \
              b   c       a   b        a   b            b   c      */
-      if (AVLBalFactor(tree,q) == 1) {    /* was: > 0 */
-          SetAVLRight(tree,q,AVLLeft(tree,p));
-          SetAVLLeft(tree,p,q);
-          SetAVLBalFactor(tree,q,0);
-          SetAVLBalFactor(tree,p,0);
-          SetAVLRank(tree,p,AVLRank(tree,p) + AVLRank(tree,q));
+      if (DS_AVLBalFactor(tree,q) == 1) {    /* was: > 0 */
+          SetDS_AVLRight(tree,q,DS_AVLLeft(tree,p));
+          SetDS_AVLLeft(tree,p,q);
+          SetDS_AVLBalFactor(tree,q,0);
+          SetDS_AVLBalFactor(tree,p,0);
+          SetDS_AVLRank(tree,p,DS_AVLRank(tree,p) + DS_AVLRank(tree,q));
       } else {
-          SetAVLLeft(tree,q,AVLRight(tree,p));
-          SetAVLRight(tree,p,q);
-          SetAVLBalFactor(tree,q,0);
-          SetAVLBalFactor(tree,p,0);
-          SetAVLRank(tree,q,AVLRank(tree,q) - AVLRank(tree,p));
+          SetDS_AVLLeft(tree,q,DS_AVLRight(tree,p));
+          SetDS_AVLRight(tree,p,q);
+          SetDS_AVLBalFactor(tree,q,0);
+          SetDS_AVLBalFactor(tree,p,0);
+          SetDS_AVLRank(tree,q,DS_AVLRank(tree,q) - DS_AVLRank(tree,p));
       }
-  } else if (AVLBalFactor(tree,p) == 3 - AVLBalFactor(tree,q)) {
+  } else if (DS_AVLBalFactor(tree,p) == 3 - DS_AVLBalFactor(tree,q)) {
               /* was: = - */
        /* we need a double rotation:
              q++                             q--
@@ -387,89 +387,89 @@ Int AVLFind( Obj t, Obj d )
              c   e      / \   / \        a   c         / \   / \
             / \        a   b d   e          / \       a   b d   e
            b   d                           b   d                     */
-      if (AVLBalFactor(tree,q) == 1) {   /* was: > 0 */
-          l = AVLLeft(tree,p);
-          SetAVLRight(tree,q,AVLLeft(tree,l));
-          SetAVLLeft(tree,p,AVLRight(tree,l));
-          SetAVLLeft(tree,l,q);
-          SetAVLRight(tree,l,p);
-          if (AVLBalFactor(tree,l) == 1) {   /* was: > 0 */
-              SetAVLBalFactor(tree,p,0);
-              SetAVLBalFactor(tree,q,2);     /* was: -1 */
-          } else if (AVLBalFactor(tree,l) == 0) {
-              SetAVLBalFactor(tree,p,0);
-              SetAVLBalFactor(tree,q,0);
-          } else {   /* AVLBalFactor(tree,l) < 0 */
-              SetAVLBalFactor(tree,p,1);
-              SetAVLBalFactor(tree,q,0);
+      if (DS_AVLBalFactor(tree,q) == 1) {   /* was: > 0 */
+          l = DS_AVLLeft(tree,p);
+          SetDS_AVLRight(tree,q,DS_AVLLeft(tree,l));
+          SetDS_AVLLeft(tree,p,DS_AVLRight(tree,l));
+          SetDS_AVLLeft(tree,l,q);
+          SetDS_AVLRight(tree,l,p);
+          if (DS_AVLBalFactor(tree,l) == 1) {   /* was: > 0 */
+              SetDS_AVLBalFactor(tree,p,0);
+              SetDS_AVLBalFactor(tree,q,2);     /* was: -1 */
+          } else if (DS_AVLBalFactor(tree,l) == 0) {
+              SetDS_AVLBalFactor(tree,p,0);
+              SetDS_AVLBalFactor(tree,q,0);
+          } else {   /* DS_AVLBalFactor(tree,l) < 0 */
+              SetDS_AVLBalFactor(tree,p,1);
+              SetDS_AVLBalFactor(tree,q,0);
           }
-          SetAVLBalFactor(tree,l,0);
-          SetAVLRank(tree,p,AVLRank(tree,p) - AVLRank(tree,l));
-          SetAVLRank(tree,l,AVLRank(tree,l) + AVLRank(tree,q));
+          SetDS_AVLBalFactor(tree,l,0);
+          SetDS_AVLRank(tree,p,DS_AVLRank(tree,p) - DS_AVLRank(tree,l));
+          SetDS_AVLRank(tree,l,DS_AVLRank(tree,l) + DS_AVLRank(tree,q));
           p = l;
       } else {
-          l = AVLRight(tree,p);
-          SetAVLLeft(tree,q,AVLRight(tree,l));
-          SetAVLRight(tree,p,AVLLeft(tree,l));
-          SetAVLLeft(tree,l,p);
-          SetAVLRight(tree,l,q);
-          if (AVLBalFactor(tree,l) == 2) {  /* was: < 0 */
-              SetAVLBalFactor(tree,p,0);
-              SetAVLBalFactor(tree,q,1);
-          } else if (AVLBalFactor(tree,l) == 0) {
-              SetAVLBalFactor(tree,p,0);
-              SetAVLBalFactor(tree,q,0);
-          } else {   /* AVLBalFactor(tree,l) > 0 */
-              SetAVLBalFactor(tree,p,2);  /* was: -1 */
-              SetAVLBalFactor(tree,q,0);
+          l = DS_AVLRight(tree,p);
+          SetDS_AVLLeft(tree,q,DS_AVLRight(tree,l));
+          SetDS_AVLRight(tree,p,DS_AVLLeft(tree,l));
+          SetDS_AVLLeft(tree,l,p);
+          SetDS_AVLRight(tree,l,q);
+          if (DS_AVLBalFactor(tree,l) == 2) {  /* was: < 0 */
+              SetDS_AVLBalFactor(tree,p,0);
+              SetDS_AVLBalFactor(tree,q,1);
+          } else if (DS_AVLBalFactor(tree,l) == 0) {
+              SetDS_AVLBalFactor(tree,p,0);
+              SetDS_AVLBalFactor(tree,q,0);
+          } else {   /* DS_AVLBalFactor(tree,l) > 0 */
+              SetDS_AVLBalFactor(tree,p,2);  /* was: -1 */
+              SetDS_AVLBalFactor(tree,q,0);
           }
-          SetAVLBalFactor(tree,l,0);
-          SetAVLRank(tree,l,AVLRank(tree,l) + AVLRank(tree,p));
-          SetAVLRank(tree,q,AVLRank(tree,q) - AVLRank(tree,l));
-                               /* new value of AVLRank(tree,l)! */
+          SetDS_AVLBalFactor(tree,l,0);
+          SetDS_AVLRank(tree,l,DS_AVLRank(tree,l) + DS_AVLRank(tree,p));
+          SetDS_AVLRank(tree,q,DS_AVLRank(tree,q) - DS_AVLRank(tree,l));
+                               /* new value of DS_AVLRank(tree,l)! */
           p = l;
       }
-  } else {  /* AVLBalFactor(tree,p) = 0 */
+  } else {  /* DS_AVLBalFactor(tree,p) = 0 */
       /* we need a single rotation:
             q++             p-           q--          p+
            / \             / \          / \          / \
           a   p=    ==>   q+  c    OR  p=  c   ==>  a   q-
              / \         / \          / \              / \
             b   c       a   b        a   b            b   c    */
-      if (AVLBalFactor(tree,q) == 1) {   /* was: > 0 */
-          SetAVLRight(tree,q,AVLLeft(tree,p));
-          SetAVLLeft(tree,p,q);
-          SetAVLBalFactor(tree,q,1);
-          SetAVLBalFactor(tree,p,2);   /* was: -1 */
-          SetAVLRank(tree,p,AVLRank(tree,p) + AVLRank(tree,q));
+      if (DS_AVLBalFactor(tree,q) == 1) {   /* was: > 0 */
+          SetDS_AVLRight(tree,q,DS_AVLLeft(tree,p));
+          SetDS_AVLLeft(tree,p,q);
+          SetDS_AVLBalFactor(tree,q,1);
+          SetDS_AVLBalFactor(tree,p,2);   /* was: -1 */
+          SetDS_AVLRank(tree,p,DS_AVLRank(tree,p) + DS_AVLRank(tree,q));
       } else {
-          SetAVLLeft(tree,q,AVLRight(tree,p));
-          SetAVLRight(tree,p,q);
-          SetAVLBalFactor(tree,q,2);  /* was: -1 */
-          SetAVLBalFactor(tree,p,1);
-          SetAVLRank(tree,q,AVLRank(tree,q) - AVLRank(tree,p));
+          SetDS_AVLLeft(tree,q,DS_AVLRight(tree,p));
+          SetDS_AVLRight(tree,p,q);
+          SetDS_AVLBalFactor(tree,q,2);  /* was: -1 */
+          SetDS_AVLBalFactor(tree,p,1);
+          SetDS_AVLRank(tree,q,DS_AVLRank(tree,q) - DS_AVLRank(tree,p));
       }
       *shrink = 0;
   }
   *newroot = p;
 }
 
- Obj AVLRebalance_C( Obj self, Obj tree, Obj q )
+ Obj DS_AVLRebalance_C( Obj self, Obj tree, Obj q )
 {
     Int newroot = 0;
     int shrink;
     Obj tmp;
-    AVLRebalance( tree, INT_INTOBJ(q), &newroot, &shrink );
+    DS_AVLRebalance( tree, INT_INTOBJ(q), &newroot, &shrink );
     tmp = NEW_PREC(2);
     AssPRec(tmp,RNamName("newroot"),INTOBJ_INT(newroot));
     AssPRec(tmp,RNamName("shorter"),shrink ? True : False);
     return tmp;
 }
 
- Obj AVLAdd_C( Obj self, Obj tree, Obj data, Obj value )
+ Obj DS_AVLAdd_C( Obj self, Obj tree, Obj data, Obj value )
 {
 /* Parameters: tree, data, value
-    tree is an AVL tree
+    tree is an DS_AVL tree
     data is a data structure defined by the user
     value is the value stored under the key data, if true, nothing is stored
    Tries to add the data as a node in tree. It is an error, if there is
@@ -491,24 +491,24 @@ Int AVLFind( Obj t, Obj d )
   Int i;
   int shrink;
 
-  if (TNUM_OBJ(tree) != T_POSOBJ || TYPE_POSOBJ(tree) != AVLTreeTypeMutable) {
-      ErrorQuit( "Usage: AVLAdd(avltree, object, object)", 0L, 0L );
+  if (TNUM_OBJ(tree) != T_POSOBJ || TYPE_POSOBJ(tree) != DS_AVLTreeTypeMutable) {
+      ErrorQuit( "Usage: DS_AVLAdd(avltree, object, object)", 0L, 0L );
       return 0L;
   }
 
-  compare = AVL3Comp(tree);
-  p = AVLTop(tree);
+  compare = DS_AVL3Comp(tree);
+  p = DS_AVLTop(tree);
   if (p == 0) {   /* A new, single node in the tree */
-      new = AVLNewNode(tree);
-      SetAVLLeft(tree,new,0);
-      SetAVLRight(tree,new,0);
-      SetAVLBalFactor(tree,new,0);
-      SetAVLRank(tree,new,1);
-      SetAVLData(tree,new,data);
+      new = DS_AVLNewNode(tree);
+      SetDS_AVLLeft(tree,new,0);
+      SetDS_AVLRight(tree,new,0);
+      SetDS_AVLBalFactor(tree,new,0);
+      SetDS_AVLRank(tree,new,1);
+      SetDS_AVLData(tree,new,data);
       if (value != True)
-          SetAVLValue(tree,new,value);
-      SetAVLNodes(tree,1);
-      SetAVLTop(tree,new);
+          SetDS_AVLValue(tree,new,value);
+      SetDS_AVLNodes(tree,1);
+      SetDS_AVLTop(tree,new);
       return True;
   }
 
@@ -525,25 +525,25 @@ Int AVLFind( Obj t, Obj d )
   rankaddslen = 0;  /* nothing done so far, list of Rank-modified nodes */
   do {
       /* do we have to remember this position? */
-      if (AVLBalFactor(tree,p) != 0)
+      if (DS_AVLBalFactor(tree,p) != 0)
           q = n;       /* forget old last node with balance factor != 0 */
 
       /* now one step: */
-      c = INT_INTOBJ(CALL_2ARGS(compare,data,AVLData(tree,p)));
+      c = INT_INTOBJ(CALL_2ARGS(compare,data,DS_AVLData(tree,p)));
       if (c == 0) {   /* we did not want this! */
           for (p = 1; p <= rankaddslen; p++) {
-            SetAVLRank(tree,p,AVLRank(tree,rankadds[p]) - 1);
+            SetDS_AVLRank(tree,p,DS_AVLRank(tree,rankadds[p]) - 1);
           }
           return Fail;    /* tree is unchanged */
       }
 
       l = p;     /* remember last position */
-      if (c < 0) {    /* data < AVLData(tree,p) */
-          SetAVLRank(tree,p,AVLRank(tree,p) + 1);
+      if (c < 0) {    /* data < DS_AVLData(tree,p) */
+          SetDS_AVLRank(tree,p,DS_AVLRank(tree,p) + 1);
           rankadds[++rankaddslen] = p;
-          p = AVLLeft(tree,p);
-      } else {        /* data > AVLData(tree,p) */
-          p = AVLRight(tree,p);
+          p = DS_AVLLeft(tree,p);
+      } else {        /* data > DS_AVLData(tree,p) */
+          p = DS_AVLRight(tree,p);
       }
       path[n] = c > 0 ? 1 : 2;   /* Internal representation! */
       nodes[++n] = p;
@@ -554,57 +554,57 @@ Int AVLFind( Obj t, Obj d )
   l = nodes[n-1];   /* for easier reference */
 
   /* a new node: */
-  p = AVLNewNode(tree);
-  SetAVLLeft(tree,p,0);
-  SetAVLRight(tree,p,0);
-  SetAVLBalFactor(tree,p,0);
-  SetAVLRank(tree,p,1);
-  SetAVLData(tree,p,data);
+  p = DS_AVLNewNode(tree);
+  SetDS_AVLLeft(tree,p,0);
+  SetDS_AVLRight(tree,p,0);
+  SetDS_AVLBalFactor(tree,p,0);
+  SetDS_AVLRank(tree,p,1);
+  SetDS_AVLData(tree,p,data);
   if (value != True) {
-      SetAVLValue(tree,p,value);
+      SetDS_AVLValue(tree,p,value);
   }
   /* insert into tree: */
   if (c < 0) {    /* left */
-      SetAVLLeft(tree,l,p);
+      SetDS_AVLLeft(tree,l,p);
   } else {
-      SetAVLRight(tree,l,p);
+      SetDS_AVLRight(tree,l,p);
   }
-  SetAVLNodes(tree,AVLNodes(tree)+1);
+  SetDS_AVLNodes(tree,DS_AVLNodes(tree)+1);
 
   /* modify balance factors between q and l: */
   for (i = q+1;i <= n-1;i++) {
-      SetAVLBalFactor(tree,nodes[i],path[i]);
+      SetDS_AVLBalFactor(tree,nodes[i],path[i]);
   }
 
   /* is rebalancing at q necessary? */
   if (q == 0)     /* whole tree has grown one step */
       return True;
-  if (AVLBalFactor(tree,nodes[q]) == 3-path[q]) {
+  if (DS_AVLBalFactor(tree,nodes[q]) == 3-path[q]) {
       /* the subtree at q has gotten more balanced */
-      SetAVLBalFactor(tree,nodes[q],0);
+      SetDS_AVLBalFactor(tree,nodes[q],0);
       return True;   /* Success! */
   }
 
   /* now at last we do have to rebalance at nodes[q] because the tree has
      gotten out of balance: */
-  AVLRebalance(tree,nodes[q],&p,&shrink);
+  DS_AVLRebalance(tree,nodes[q],&p,&shrink);
 
   /* finishing touch: link new root of subtree (p) to t: */
   if (q == 1) {    /* q resp. r was First node */
-      SetAVLTop(tree,p);
+      SetDS_AVLTop(tree,p);
   } else if (path[q-1] == 2) {
-      SetAVLLeft(tree,nodes[q-1],p);
+      SetDS_AVLLeft(tree,nodes[q-1],p);
   } else {
-      SetAVLRight(tree,nodes[q-1],p);
+      SetDS_AVLRight(tree,nodes[q-1],p);
   }
 
   return True;
 }
 
- Obj AVLIndexAdd_C( Obj self, Obj tree, Obj data, Obj value, Obj ind )
+ Obj DS_AVLIndexAdd_C( Obj self, Obj tree, Obj data, Obj value, Obj ind )
 {
 /* Parameters: tree, data, value
-    tree is an AVL tree
+    tree is an DS_AVL tree
     data is a data structure defined by the user
     value is the value stored under the key data, if true, nothing is stored
     index is the index, where data should be inserted in tree 1 ist at
@@ -625,26 +625,26 @@ Int AVLFind( Obj t, Obj d )
   Int offset;
   int shrink;
 
-  if (TNUM_OBJ(tree) != T_POSOBJ || TYPE_POSOBJ(tree) != AVLTreeTypeMutable) {
-      ErrorQuit( "Usage: AVLAdd(avltree, object, object)", 0L, 0L );
+  if (TNUM_OBJ(tree) != T_POSOBJ || TYPE_POSOBJ(tree) != DS_AVLTreeTypeMutable) {
+      ErrorQuit( "Usage: DS_AVLAdd(avltree, object, object)", 0L, 0L );
       return 0L;
   }
 
   index = INT_INTOBJ(ind);
-  if (index < 1 || index > AVLNodes(tree)+1) return Fail;
+  if (index < 1 || index > DS_AVLNodes(tree)+1) return Fail;
 
-  p = AVLTop(tree);
+  p = DS_AVLTop(tree);
   if (p == 0) {   /* A new, single node in the tree */
-      new = AVLNewNode(tree);
-      SetAVLLeft(tree,new,0);
-      SetAVLRight(tree,new,0);
-      SetAVLBalFactor(tree,new,0);
-      SetAVLRank(tree,new,1);
-      SetAVLData(tree,new,data);
+      new = DS_AVLNewNode(tree);
+      SetDS_AVLLeft(tree,new,0);
+      SetDS_AVLRight(tree,new,0);
+      SetDS_AVLBalFactor(tree,new,0);
+      SetDS_AVLRank(tree,new,1);
+      SetDS_AVLData(tree,new,data);
       if (value != True)
-          SetAVLValue(tree,new,value);
-      SetAVLNodes(tree,1);
-      SetAVLTop(tree,new);
+          SetDS_AVLValue(tree,new,value);
+      SetDS_AVLNodes(tree,1);
+      SetDS_AVLTop(tree,new);
       return True;
   }
 
@@ -662,22 +662,22 @@ Int AVLFind( Obj t, Obj d )
 
   do {
       /* do we have to remember this position? */
-      if (AVLBalFactor(tree,p) != 0)
+      if (DS_AVLBalFactor(tree,p) != 0)
           q = n;       /* forget old last node with balance factor != 0 */
 
       /* now one step: */
-      if (index <= offset+AVLRank(tree,p))
+      if (index <= offset+DS_AVLRank(tree,p))
           c = -1;
       else
           c = +1;
 
       l = p;     /* remember last position */
-      if (c < 0) {    /* data < AVLData(tree,p) */
-          SetAVLRank(tree,p,AVLRank(tree,p) + 1);
-          p = AVLLeft(tree,p);
-      } else {        /* data > AVLData(tree,p) */
-          offset += AVLRank(tree,p);
-          p = AVLRight(tree,p);
+      if (c < 0) {    /* data < DS_AVLData(tree,p) */
+          SetDS_AVLRank(tree,p,DS_AVLRank(tree,p) + 1);
+          p = DS_AVLLeft(tree,p);
+      } else {        /* data > DS_AVLData(tree,p) */
+          offset += DS_AVLRank(tree,p);
+          p = DS_AVLRight(tree,p);
       }
       path[n] = c > 0 ? 1 : 2;   /* Internal representation! */
       nodes[++n] = p;
@@ -688,56 +688,56 @@ Int AVLFind( Obj t, Obj d )
   l = nodes[n-1];   /* for easier reference */
 
   /* a new node: */
-  p = AVLNewNode(tree);
-  SetAVLLeft(tree,p,0);
-  SetAVLRight(tree,p,0);
-  SetAVLBalFactor(tree,p,0);
-  SetAVLRank(tree,p,1);
-  SetAVLData(tree,p,data);
+  p = DS_AVLNewNode(tree);
+  SetDS_AVLLeft(tree,p,0);
+  SetDS_AVLRight(tree,p,0);
+  SetDS_AVLBalFactor(tree,p,0);
+  SetDS_AVLRank(tree,p,1);
+  SetDS_AVLData(tree,p,data);
   if (value != True) {
-      SetAVLValue(tree,p,value);
+      SetDS_AVLValue(tree,p,value);
   }
   /* insert into tree: */
   if (c < 0) {    /* left */
-      SetAVLLeft(tree,l,p);
+      SetDS_AVLLeft(tree,l,p);
   } else {
-      SetAVLRight(tree,l,p);
+      SetDS_AVLRight(tree,l,p);
   }
-  SetAVLNodes(tree,AVLNodes(tree)+1);
+  SetDS_AVLNodes(tree,DS_AVLNodes(tree)+1);
 
   /* modify balance factors between q and l: */
   for (i = q+1;i <= n-1;i++) {
-      SetAVLBalFactor(tree,nodes[i],path[i]);
+      SetDS_AVLBalFactor(tree,nodes[i],path[i]);
   }
 
   /* is rebalancing at q necessary? */
   if (q == 0)     /* whole tree has grown one step */
       return True;
-  if (AVLBalFactor(tree,nodes[q]) == 3-path[q]) {
+  if (DS_AVLBalFactor(tree,nodes[q]) == 3-path[q]) {
       /* the subtree at q has gotten more balanced */
-      SetAVLBalFactor(tree,nodes[q],0);
+      SetDS_AVLBalFactor(tree,nodes[q],0);
       return True;   /* Success! */
   }
 
   /* now at last we do have to rebalance at nodes[q] because the tree has
      gotten out of balance: */
-  AVLRebalance(tree,nodes[q],&p,&shrink);
+  DS_AVLRebalance(tree,nodes[q],&p,&shrink);
 
   /* finishing touch: link new root of subtree (p) to t: */
   if (q == 1) {    /* q resp. r was First node */
-      SetAVLTop(tree,p);
+      SetDS_AVLTop(tree,p);
   } else if (path[q-1] == 2) {
-      SetAVLLeft(tree,nodes[q-1],p);
+      SetDS_AVLLeft(tree,nodes[q-1],p);
   } else {
-      SetAVLRight(tree,nodes[q-1],p);
+      SetDS_AVLRight(tree,nodes[q-1],p);
   }
 
   return True;
 }
 
- Obj AVLDelete_C( Obj self, Obj tree, Obj data)
+ Obj DS_AVLDelete_C( Obj self, Obj tree, Obj data)
   /* Parameters: tree, data
-      tree is an AVL tree
+      tree is an DS_AVL tree
       data is a data structure defined by the user
      Tries to find data as a node in the tree. If found, this node is deleted
      and the tree rebalanced. It is an error, of the node is not found.
@@ -755,21 +755,21 @@ Int AVLFind( Obj t, Obj d )
   int ranksubslen;    /* length of list randsubs */
   Obj old;
 
-  if (TNUM_OBJ(tree) != T_POSOBJ || TYPE_POSOBJ(tree) != AVLTreeTypeMutable) {
-      ErrorQuit( "Usage: AVLDelete(avltree, object)", 0L, 0L );
+  if (TNUM_OBJ(tree) != T_POSOBJ || TYPE_POSOBJ(tree) != DS_AVLTreeTypeMutable) {
+      ErrorQuit( "Usage: DS_AVLDelete(avltree, object)", 0L, 0L );
       return Fail;
   }
 
-  compare = AVL3Comp(tree);
-  p = AVLTop(tree);
+  compare = DS_AVL3Comp(tree);
+  p = DS_AVLTop(tree);
   if (p == 0)     /* Nothing to delete or find */
       return Fail;
 
-  if (AVLNodes(tree) == 1) {
-      if (INT_INTOBJ(CALL_2ARGS(compare,data,AVLData(tree,p))) == 0) {
-          SetAVLNodes(tree,0);
-          SetAVLTop(tree,0);
-          return AVLFreeNode(tree,p);
+  if (DS_AVLNodes(tree) == 1) {
+      if (INT_INTOBJ(CALL_2ARGS(compare,data,DS_AVLData(tree,p))) == 0) {
+          SetDS_AVLNodes(tree,0);
+          SetDS_AVLTop(tree,0);
+          return DS_AVLFreeNode(tree,p);
       } else {
           return Fail;
       }
@@ -786,15 +786,15 @@ Int AVLFind( Obj t, Obj d )
   do {
 
       /* what is the next step? */
-      c = INT_INTOBJ(CALL_2ARGS(compare,data,AVLData(tree,p)));
+      c = INT_INTOBJ(CALL_2ARGS(compare,data,DS_AVLData(tree,p)));
 
       if (c != 0) {    /* only if data not found! */
-          if (c < 0) {    /* data < AVLData(tree,p) */
-              SetAVLRank(tree,p,AVLRank(tree,p) - 1);
+          if (c < 0) {    /* data < DS_AVLData(tree,p) */
+              SetDS_AVLRank(tree,p,DS_AVLRank(tree,p) - 1);
               ranksubs[++ranksubslen] = p;
-              p = AVLLeft(tree,p);
-          } else {        /* data > AVLData(tree,p) */
-              p = AVLRight(tree,p);
+              p = DS_AVLLeft(tree,p);
+          } else {        /* data > DS_AVLData(tree,p) */
+              p = DS_AVLRight(tree,p);
           }
           path[n] = c > 0 ? 1 : 2;   /* Internal representation! */
           nodes[++n] = p;
@@ -803,51 +803,51 @@ Int AVLFind( Obj t, Obj d )
       if (p == 0) {
           /* error, we did not find data */
           for (i = 1; i <= ranksubslen; i++) {
-              SetAVLRank(tree,ranksubs[i],AVLRank(tree,ranksubs[i]) + 1);
+              SetDS_AVLRank(tree,ranksubs[i],DS_AVLRank(tree,ranksubs[i]) + 1);
           }
           return Fail;
       }
 
   } while (c != 0);   /* until we find the right node */
-  /* now data is equal to AVLData(tree,p) so this node p must be removed.
-     the tree must be modified between AVLTop(tree) and nodes[n] along path
+  /* now data is equal to DS_AVLData(tree,p) so this node p must be removed.
+     the tree must be modified between DS_AVLTop(tree) and nodes[n] along path
      Ranks are already done up there. */
 
   /* now we have to search a neighbour, we modify "nodes" and "path" but
    * not n! */
   m = n;
-  if (AVLBalFactor(tree,p) == 2) {   /* (was: < 0) search to the left */
-      l = AVLLeft(tree,p);   /* must be a node! */
-      SetAVLRank(tree,p,AVLRank(tree,p) - 1);
+  if (DS_AVLBalFactor(tree,p) == 2) {   /* (was: < 0) search to the left */
+      l = DS_AVLLeft(tree,p);   /* must be a node! */
+      SetDS_AVLRank(tree,p,DS_AVLRank(tree,p) - 1);
       /* we will delete in left subtree! */
       path[m] = 2;   /* was: -1 */
       nodes[++m] = l;
-      while (AVLRight(tree,l) != 0) {
-          l = AVLRight(tree,l);
+      while (DS_AVLRight(tree,l) != 0) {
+          l = DS_AVLRight(tree,l);
           path[m] = 1;
           nodes[++m] = l;
       }
       c = -1;       /* we got predecessor */
-  } else if (AVLBalFactor(tree,p) > 0) {  /* search to the right */
-      l = AVLRight(tree,p);      /* must be a node! */
+  } else if (DS_AVLBalFactor(tree,p) > 0) {  /* search to the right */
+      l = DS_AVLRight(tree,p);      /* must be a node! */
       path[m] = 1;
       nodes[++m] = l;
-      while (AVLLeft(tree,l) != 0) {
-          SetAVLRank(tree,l,AVLRank(tree,l) - 1);
+      while (DS_AVLLeft(tree,l) != 0) {
+          SetDS_AVLRank(tree,l,DS_AVLRank(tree,l) - 1);
           /* we will delete in left subtree! */
-          l = AVLLeft(tree,l);
+          l = DS_AVLLeft(tree,l);
           path[m] = 2;  /* was: -1 */
           nodes[++m] = l;
       }
       c = 1;        /* we got successor */
   } else {   /* equal depths */
-      if (AVLLeft(tree,p) != 0) {
-          l = AVLLeft(tree,p);
-          SetAVLRank(tree,p,AVLRank(tree,p) - 1);
+      if (DS_AVLLeft(tree,p) != 0) {
+          l = DS_AVLLeft(tree,p);
+          SetDS_AVLRank(tree,p,DS_AVLRank(tree,p) - 1);
           path[m] = 2;   /* was: -1 */
           nodes[++m] = l;
-          while (AVLRight(tree,l) != 0) {
-              l = AVLRight(tree,l);
+          while (DS_AVLRight(tree,l) != 0) {
+              l = DS_AVLRight(tree,l);
               path[m] = 1;
               nodes[++m] = l;
           }
@@ -862,22 +862,22 @@ Int AVLFind( Obj t, Obj d )
      "nodes" and "path" is updated, but n could be < m */
 
   /* Copy Data from l up to p: order is NOT modified */
-  SetAVLData(tree,p,AVLData(tree,l));
+  SetDS_AVLData(tree,p,DS_AVLData(tree,l));
      /* works for m = n, i.e. if p is end node */
 
   /* Delete node at l = nodes[m] by modifying nodes[m-1]:
      Note: nodes[m] has maximal one subtree! */
   if (c <= 0)
-      r = AVLLeft(tree,l);
+      r = DS_AVLLeft(tree,l);
   else    /*  c > 0 */
-      r = AVLRight(tree,l);
+      r = DS_AVLRight(tree,l);
 
   if (path[m-1] == 2)    /* was: < 0 */
-      SetAVLLeft(tree,nodes[m-1],r);
+      SetDS_AVLLeft(tree,nodes[m-1],r);
   else
-      SetAVLRight(tree,nodes[m-1],r);
-  SetAVLNodes(tree,AVLNodes(tree)-1);
-  old = AVLFreeNode(tree,l);
+      SetDS_AVLRight(tree,nodes[m-1],r);
+  SetDS_AVLNodes(tree,DS_AVLNodes(tree)-1);
+  old = DS_AVLFreeNode(tree,l);
 
   /* modify balance factors:
      the subtree nodes[m-1] has become shorter at its left (resp. right)
@@ -887,21 +887,21 @@ Int AVLFind( Obj t, Obj d )
      (we decrement m and work until the corresponding subtree has not shrunk) */
   m--;   /* start work HERE */
   while (m >= 1) {
-      if (AVLBalFactor(tree,nodes[m]) == 0) {
-          SetAVLBalFactor(tree,nodes[m],3-path[m]); /* we made path[m] shorter*/
+      if (DS_AVLBalFactor(tree,nodes[m]) == 0) {
+          SetDS_AVLBalFactor(tree,nodes[m],3-path[m]); /* we made path[m] shorter*/
           return old;
-      } else if (AVLBalFactor(tree,nodes[m]) == path[m]) {
-          SetAVLBalFactor(tree,nodes[m],0);     /* we made path[m] shorter */
+      } else if (DS_AVLBalFactor(tree,nodes[m]) == path[m]) {
+          SetDS_AVLBalFactor(tree,nodes[m],0);     /* we made path[m] shorter */
       } else {   /* tree is out of balance */
           int shorter;
-          AVLRebalance(tree,nodes[m],&p,&shorter);
+          DS_AVLRebalance(tree,nodes[m],&p,&shorter);
           if (m == 1) {
-              SetAVLTop(tree,p);
+              SetDS_AVLTop(tree,p);
               return old;               /* everything is done */
           } else if (path[m-1] == 2)   /* was: = -1 */
-              SetAVLLeft(tree,nodes[m-1],p);
+              SetDS_AVLLeft(tree,nodes[m-1],p);
           else
-              SetAVLRight(tree,nodes[m-1],p);
+              SetDS_AVLRight(tree,nodes[m-1],p);
           if (!shorter) return old;    /* nothing happens further up */
       }
       m--;
@@ -909,11 +909,11 @@ Int AVLFind( Obj t, Obj d )
   return old;
 }
 
- Obj AVLIndexDelete_C( Obj self, Obj tree, Obj index)
+ Obj DS_AVLIndexDelete_C( Obj self, Obj tree, Obj index)
   /* Parameters: tree, index
-      tree is an AVL tree
+      tree is an DS_AVL tree
       index is the index of the element to be deleted, must be between 1 and
-          AVLNodes(tree) inclusively
+          DS_AVLNodes(tree) inclusively
      returns fail if index is out of range, otherwise the deleted key;  */
 
 {
@@ -928,28 +928,28 @@ Int AVLFind( Obj t, Obj d )
   Int ind;
   Obj x;
 
-  if (TNUM_OBJ(tree) != T_POSOBJ || TYPE_POSOBJ(tree) != AVLTreeTypeMutable) {
-      ErrorQuit( "Usage: AVLIndexDelete(avltree, index)", 0L, 0L );
+  if (TNUM_OBJ(tree) != T_POSOBJ || TYPE_POSOBJ(tree) != DS_AVLTreeTypeMutable) {
+      ErrorQuit( "Usage: DS_AVLIndexDelete(avltree, index)", 0L, 0L );
       return 0L;
   }
   if (!IS_INTOBJ(index)) {
-      ErrorQuit( "Usage2: AVLIndexDelete(avltree, index)", 0L, 0L );
+      ErrorQuit( "Usage2: DS_AVLIndexDelete(avltree, index)", 0L, 0L );
       return 0L;
   }
 
-  p = AVLTop(tree);
+  p = DS_AVLTop(tree);
   if (p == 0)     /* Nothing to delete or find */
       return Fail;
 
   ind = INT_INTOBJ(index);
-  if (ind < 1 || ind > AVLNodes(tree))   /* out of range */
+  if (ind < 1 || ind > DS_AVLNodes(tree))   /* out of range */
       return Fail;
 
-  if (AVLNodes(tree) == 1) {
-      x = AVLData(tree,p);
-      SetAVLNodes(tree,0);
-      SetAVLTop(tree,0);
-      AVLFreeNode(tree,p);
+  if (DS_AVLNodes(tree) == 1) {
+      x = DS_AVLData(tree,p);
+      SetDS_AVLNodes(tree,0);
+      SetDS_AVLTop(tree,0);
+      DS_AVLFreeNode(tree,p);
       return x;
   }
 
@@ -964,21 +964,21 @@ Int AVLFind( Obj t, Obj d )
   do {
 
       /* what is the next step? */
-      if (ind == offset + AVLRank(tree,p)) {
+      if (ind == offset + DS_AVLRank(tree,p)) {
           c = 0;   /* we found our node! */
-          x = AVLData(tree,p);
-      } else if (ind < offset + AVLRank(tree,p))
+          x = DS_AVLData(tree,p);
+      } else if (ind < offset + DS_AVLRank(tree,p))
           c = -1;  /* we have to go left */
       else
           c = 1;   /* we have to go right */
 
       if (c != 0) {    /* only if data not found! */
-          if (c < 0) {    /* data < AVLData(tree,p) */
-              SetAVLRank(tree,p,AVLRank(tree,p) - 1);
-              p = AVLLeft(tree,p);
-          } else {        /* data > AVLData(tree,p) */
-              offset += AVLRank(tree,p);
-              p = AVLRight(tree,p);
+          if (c < 0) {    /* data < DS_AVLData(tree,p) */
+              SetDS_AVLRank(tree,p,DS_AVLRank(tree,p) - 1);
+              p = DS_AVLLeft(tree,p);
+          } else {        /* data > DS_AVLData(tree,p) */
+              offset += DS_AVLRank(tree,p);
+              p = DS_AVLRight(tree,p);
           }
           path[n] = c > 0 ? 1 : 2;   /* Internal representation! */
           nodes[++n] = p;
@@ -986,44 +986,44 @@ Int AVLFind( Obj t, Obj d )
 
   } while (c != 0);   /* until we find the right node */
   /* now index is right, so this node p must be removed.
-     the tree must be modified between AVLTop(tree) and nodes[n] along path
+     the tree must be modified between DS_AVLTop(tree) and nodes[n] along path
      Ranks are already done up there. */
 
   /* now we have to search a neighbour, we modify "nodes" and "path" but
    * not n! */
   m = n;
-  if (AVLBalFactor(tree,p) == 2) {   /* (was: < 0) search to the left */
-      l = AVLLeft(tree,p);   /* must be a node! */
-      SetAVLRank(tree,p,AVLRank(tree,p) - 1);
+  if (DS_AVLBalFactor(tree,p) == 2) {   /* (was: < 0) search to the left */
+      l = DS_AVLLeft(tree,p);   /* must be a node! */
+      SetDS_AVLRank(tree,p,DS_AVLRank(tree,p) - 1);
       /* we will delete in left subtree! */
       path[m] = 2;   /* was: -1 */
       nodes[++m] = l;
-      while (AVLRight(tree,l) != 0) {
-          l = AVLRight(tree,l);
+      while (DS_AVLRight(tree,l) != 0) {
+          l = DS_AVLRight(tree,l);
           path[m] = 1;
           nodes[++m] = l;
       }
       c = -1;       /* we got predecessor */
-  } else if (AVLBalFactor(tree,p) > 0) {  /* search to the right */
-      l = AVLRight(tree,p);      /* must be a node! */
+  } else if (DS_AVLBalFactor(tree,p) > 0) {  /* search to the right */
+      l = DS_AVLRight(tree,p);      /* must be a node! */
       path[m] = 1;
       nodes[++m] = l;
-      while (AVLLeft(tree,l) != 0) {
-          SetAVLRank(tree,l,AVLRank(tree,l) - 1);
+      while (DS_AVLLeft(tree,l) != 0) {
+          SetDS_AVLRank(tree,l,DS_AVLRank(tree,l) - 1);
           /* we will delete in left subtree! */
-          l = AVLLeft(tree,l);
+          l = DS_AVLLeft(tree,l);
           path[m] = 2;  /* was: -1 */
           nodes[++m] = l;
       }
       c = 1;        /* we got successor */
   } else {   /* equal depths */
-      if (AVLLeft(tree,p) != 0) {
-          l = AVLLeft(tree,p);
-          SetAVLRank(tree,p,AVLRank(tree,p) - 1);
+      if (DS_AVLLeft(tree,p) != 0) {
+          l = DS_AVLLeft(tree,p);
+          SetDS_AVLRank(tree,p,DS_AVLRank(tree,p) - 1);
           path[m] = 2;   /* was: -1 */
           nodes[++m] = l;
-          while (AVLRight(tree,l) != 0) {
-              l = AVLRight(tree,l);
+          while (DS_AVLRight(tree,l) != 0) {
+              l = DS_AVLRight(tree,l);
               path[m] = 1;
               nodes[++m] = l;
           }
@@ -1038,22 +1038,22 @@ Int AVLFind( Obj t, Obj d )
      "nodes" and "path" is updated, but n could be < m */
 
   /* Copy Data from l up to p: order is NOT modified */
-  SetAVLData(tree,p,AVLData(tree,l));
+  SetDS_AVLData(tree,p,DS_AVLData(tree,l));
      /* works for m = n, i.e. if p is end node */
 
   /* Delete node at l = nodes[m] by modifying nodes[m-1]:
      Note: nodes[m] has maximal one subtree! */
   if (c <= 0)
-      r = AVLLeft(tree,l);
+      r = DS_AVLLeft(tree,l);
   else    /*  c > 0 */
-      r = AVLRight(tree,l);
+      r = DS_AVLRight(tree,l);
 
   if (path[m-1] == 2)    /* was: < 0 */
-      SetAVLLeft(tree,nodes[m-1],r);
+      SetDS_AVLLeft(tree,nodes[m-1],r);
   else
-      SetAVLRight(tree,nodes[m-1],r);
-  SetAVLNodes(tree,AVLNodes(tree)-1);
-  AVLFreeNode(tree,l);
+      SetDS_AVLRight(tree,nodes[m-1],r);
+  SetDS_AVLNodes(tree,DS_AVLNodes(tree)-1);
+  DS_AVLFreeNode(tree,l);
 
   /* modify balance factors:
      the subtree nodes[m-1] has become shorter at its left (resp. right)
@@ -1063,21 +1063,21 @@ Int AVLFind( Obj t, Obj d )
      (we decrement m and work until the corresponding subtree has not shrunk) */
   m--;   /* start work HERE */
   while (m >= 1) {
-      if (AVLBalFactor(tree,nodes[m]) == 0) {
-          SetAVLBalFactor(tree,nodes[m],3-path[m]); /* we made path[m] shorter*/
+      if (DS_AVLBalFactor(tree,nodes[m]) == 0) {
+          SetDS_AVLBalFactor(tree,nodes[m],3-path[m]); /* we made path[m] shorter*/
           return x;
-      } else if (AVLBalFactor(tree,nodes[m]) == path[m]) {
-          SetAVLBalFactor(tree,nodes[m],0);     /* we made path[m] shorter */
+      } else if (DS_AVLBalFactor(tree,nodes[m]) == path[m]) {
+          SetDS_AVLBalFactor(tree,nodes[m],0);     /* we made path[m] shorter */
       } else {   /* tree is out of balance */
           int shorter;
-          AVLRebalance(tree,nodes[m],&p,&shorter);
+          DS_AVLRebalance(tree,nodes[m],&p,&shorter);
           if (m == 1) {
-              SetAVLTop(tree,p);
+              SetDS_AVLTop(tree,p);
               return x;               /* everything is done */
           } else if (path[m-1] == 2)   /* was: = -1 */
-              SetAVLLeft(tree,nodes[m-1],p);
+              SetDS_AVLLeft(tree,nodes[m-1],p);
           else
-              SetAVLRight(tree,nodes[m-1],p);
+              SetDS_AVLRight(tree,nodes[m-1],p);
           if (!shorter) return x;    /* nothing happens further up */
       }
       m--;
@@ -1090,20 +1090,20 @@ Int AVLFind( Obj t, Obj d )
 // Submodule declaration
 //
 static StructGVarFunc GVarFuncs[] = {
-    GVARFUNC("avltree.c", AVLCmp_C, 2, "a, b"),
-    GVARFUNC("avltree.c", AVLNewNode_C, 1, "t"),
-    GVARFUNC("avltree.c", AVLFreeNode_C, 2, "tree, n"),
-    GVARFUNC("avltree.c", AVLFind_C, 2, "tree, data"),
-    GVARFUNC("avltree.c", AVLIndexFind_C, 2, "tree, i"),
-    GVARFUNC("avltree.c", AVLFindIndex_C, 2, "tree, data"),
-    GVARFUNC("avltree.c", AVLLookup_C, 2, "tree, data"),
-    GVARFUNC("avltree.c", AVLIndex_C, 2, "tree, i"),
-    GVARFUNC("avltree.c", AVLIndexLookup_C, 2, "tree, i"),
-    GVARFUNC("avltree.c", AVLRebalance_C, 2, "tree, q"),
-    GVARFUNC("avltree.c", AVLAdd_C, 3, "tree, data, value"),
-    GVARFUNC("avltree.c", AVLIndexAdd_C, 4, "tree, data, value, index"),
-    GVARFUNC("avltree.c", AVLDelete_C, 2, "tree, data"),
-    GVARFUNC("avltree.c", AVLIndexDelete_C, 2, "tree, index"),
+    GVARFUNC("avltree.c", DS_AVLCmp_C, 2, "a, b"),
+    GVARFUNC("avltree.c", DS_AVLNewNode_C, 1, "t"),
+    GVARFUNC("avltree.c", DS_AVLFreeNode_C, 2, "tree, n"),
+    GVARFUNC("avltree.c", DS_AVLFind_C, 2, "tree, data"),
+    GVARFUNC("avltree.c", DS_AVLIndexFind_C, 2, "tree, i"),
+    GVARFUNC("avltree.c", DS_AVLFindIndex_C, 2, "tree, data"),
+    GVARFUNC("avltree.c", DS_AVLLookup_C, 2, "tree, data"),
+    GVARFUNC("avltree.c", DS_AVLIndex_C, 2, "tree, i"),
+    GVARFUNC("avltree.c", DS_AVLIndexLookup_C, 2, "tree, i"),
+    GVARFUNC("avltree.c", DS_AVLRebalance_C, 2, "tree, q"),
+    GVARFUNC("avltree.c", DS_AVLAdd_C, 3, "tree, data, value"),
+    GVARFUNC("avltree.c", DS_AVLIndexAdd_C, 4, "tree, data, value, index"),
+    GVARFUNC("avltree.c", DS_AVLDelete_C, 2, "tree, data"),
+    GVARFUNC("avltree.c", DS_AVLIndexDelete_C, 2, "tree, index"),
 
     { 0 }
 };
@@ -1112,9 +1112,9 @@ static Int InitKernel(void)
 {
     InitHdlrFuncsFromTable( GVarFuncs );
 
-    ImportGVarFromLibrary( "AVLTreeType", &AVLTreeType );
-    ImportGVarFromLibrary( "AVLTreeTypeMutable", &AVLTreeTypeMutable );
-    ImportFuncFromLibrary( "AVLTree", &AVLTree );
+    ImportGVarFromLibrary( "DS_AVLTreeType", &DS_AVLTreeType );
+    ImportGVarFromLibrary( "DS_AVLTreeTypeMutable", &DS_AVLTreeTypeMutable );
+    ImportFuncFromLibrary( "DS_AVLTree", &DS_AVLTree );
     return 0;
 }
 
@@ -1124,7 +1124,7 @@ static Int InitLibrary(void)
     return 0;
 }
 
-struct DatastructuresModule AVLTreeModule = {
+struct DatastructuresModule DS_AVLTreeModule = {
     .initKernel  = InitKernel,
     .initLibrary = InitLibrary,
 };

--- a/src/avltree.h
+++ b/src/avltree.h
@@ -2,40 +2,40 @@
  * Datastructures: GAP package providing common datastructures.
  * Licensed under the GPL 2 or later.
  *
- * This file contains an AVL tree implementation,
+ * This file contains an DS_AVL tree implementation,
  * Copyright (C) 2009-2013  Max Neunhoeffer
  */
 
-#ifndef AVLTREE_H
-#define AVLTREE_H
+#ifndef DS_AVLTREE_H
+#define DS_AVLTREE_H
 
 #include "datastructures.h"
 
 // Submodule declaration
-extern struct DatastructuresModule AVLTreeModule;
+extern struct DatastructuresModule DS_AVLTreeModule;
 
-/* Interface for AVLTrees */
-extern Obj AVLTreeType;
-extern Obj AVLTreeTypeMutable;
-extern Obj AVLTree;
+/* Interface for DS_AVLTrees */
+extern Obj DS_AVLTreeType;
+extern Obj DS_AVLTreeTypeMutable;
+extern Obj DS_AVLTree;
 
-Obj AVLCmp_C(Obj self, Obj a, Obj b);
-Obj AVLNewNode_C( Obj self, Obj t );
-Obj AVLFreeNode_C( Obj self, Obj t, Obj n);
-Obj AVLFind_C( Obj self, Obj t, Obj d );
-Obj AVLIndexFind_C( Obj self, Obj t, Obj i );
-Obj AVLFindIndex_C( Obj self, Obj t, Obj d );
-Obj AVLLookup_C( Obj self, Obj t, Obj d );
-Obj AVLIndex_C( Obj self, Obj t, Obj i );
-Obj AVLIndexLookup_C( Obj self, Obj t, Obj i );
-Obj AVLRebalance_C( Obj self, Obj tree, Obj q );
-Obj AVLAdd_C( Obj self, Obj tree, Obj data, Obj value );
-Obj AVLIndexAdd_C( Obj self, Obj tree, Obj data, Obj value, Obj ind );
-Obj AVLDelete_C( Obj self, Obj tree, Obj data);
-Obj AVLIndexDelete_C( Obj self, Obj tree, Obj index);
+Obj DS_AVLCmp_C(Obj self, Obj a, Obj b);
+Obj DS_AVLNewNode_C( Obj self, Obj t );
+Obj DS_AVLFreeNode_C( Obj self, Obj t, Obj n);
+Obj DS_AVLFind_C( Obj self, Obj t, Obj d );
+Obj DS_AVLIndexFind_C( Obj self, Obj t, Obj i );
+Obj DS_AVLFindIndex_C( Obj self, Obj t, Obj d );
+Obj DS_AVLLookup_C( Obj self, Obj t, Obj d );
+Obj DS_AVLIndex_C( Obj self, Obj t, Obj i );
+Obj DS_AVLIndexLookup_C( Obj self, Obj t, Obj i );
+Obj DS_AVLRebalance_C( Obj self, Obj tree, Obj q );
+Obj DS_AVLAdd_C( Obj self, Obj tree, Obj data, Obj value );
+Obj DS_AVLIndexAdd_C( Obj self, Obj tree, Obj data, Obj value, Obj ind );
+Obj DS_AVLDelete_C( Obj self, Obj tree, Obj data);
+Obj DS_AVLIndexDelete_C( Obj self, Obj tree, Obj index);
 
-Int AVLFind( Obj t, Obj d );
-Obj AVLValue( Obj t, Int n );
-void SetAVLValue( Obj t, Int n, Obj v );
+Int DS_AVLFind( Obj t, Obj d );
+Obj DS_AVLValue( Obj t, Int n );
+void SetDS_AVLValue( Obj t, Int n, Obj v );
 
 #endif

--- a/src/datastructures.c
+++ b/src/datastructures.c
@@ -11,8 +11,8 @@
 
 // List of datastructure submodules
 static struct DatastructuresModule *submodules[] = {
-    &AVLTreeModule,
-    &HashTableModule,
+    &DS_AVLTreeModule,
+    &DS_HashTableModule,
 };
 
 #define ITERATE_SUBMODULE(func) \

--- a/src/hashtable-avl.c
+++ b/src/hashtable-avl.c
@@ -2,14 +2,14 @@
  * Datastructures: GAP package providing common datastructures.
  * Licensed under the GPL 2 or later.
  *
- * This file contains a (pseudo) hash table based on an AVL tree,
+ * This file contains a (pseudo) hash table based on an DS_AVL tree,
  *  Copyright (C) 2009-2013  Max Neunhoeffer
  */
 
 #include "hashtable-avl.h"
 #include "avltree.h"
 
-static Obj HTGrow;         /* Operation function imported from the library */
+static Obj DS_HTGrow;         /* Operation function imported from the library */
 
 static Int RNam_accesses = 0;
 static Int RNam_collisions = 0;
@@ -23,7 +23,7 @@ static Int RNam_allocsize = 0;
 static Int RNam_cangrow = 0;
 static Int RNam_len = 0;
 
-Obj HTAdd_TreeHash_C(Obj self, Obj ht, Obj x, Obj v)
+Obj DS_HTAdd_TreeHash_C(Obj self, Obj ht, Obj x, Obj v)
 {
     Obj els;
     Obj vals;
@@ -41,7 +41,7 @@ Obj HTAdd_TreeHash_C(Obj self, Obj ht, Obj x, Obj v)
     if (ElmPRec(ht,RNam_cangrow) == True &&
         INT_INTOBJ(ElmPRec(ht,RNam_nr))/10 > INT_INTOBJ(ElmPRec(ht,RNam_len)))
     {
-        CALL_2ARGS(HTGrow,ht,x);
+        CALL_2ARGS(DS_HTGrow,ht,x);
     }
 
     /* Compute hash value: */
@@ -66,19 +66,19 @@ Obj HTAdd_TreeHash_C(Obj self, Obj ht, Obj x, Obj v)
     AssPRec(ht,RNam_collisions,
             INTOBJ_INT(INT_INTOBJ(ElmPRec(ht,RNam_collisions))+1));
 
-    /* Now check whether it is an AVLTree or not: */
+    /* Now check whether it is an DS_AVLTree or not: */
     if (TNUM_OBJ(tmp) != T_POSOBJ ||
-        (TYPE_POSOBJ(tmp) != AVLTreeTypeMutable &&
-         TYPE_POSOBJ(tmp) != AVLTreeType)) {
+        (TYPE_POSOBJ(tmp) != DS_AVLTreeTypeMutable &&
+         TYPE_POSOBJ(tmp) != DS_AVLTreeType)) {
         r = NEW_PREC(2);   /* This might trigger a garbage collection */
         AssPRec(r,RNam_cmpfunc,ElmPRec(ht,RNam_cmpfunc));
         AssPRec(r,RNam_allocsize,INTOBJ_INT(3));
-        t = CALL_1ARGS(AVLTree,r);
+        t = CALL_1ARGS(DS_AVLTree,r);
         if (LEN_PLIST(vals) >= h && ELM_PLIST(vals,h) != 0L) {
-            AVLAdd_C(self,t,tmp,ELM_PLIST(vals,h));
+            DS_AVLAdd_C(self,t,tmp,ELM_PLIST(vals,h));
             UNB_LIST(vals,h);
         } else {
-            AVLAdd_C(self,t,tmp,True);
+            DS_AVLAdd_C(self,t,tmp,True);
         }
         SET_ELM_PLIST(els,h,t);
         CHANGED_BAG(els);
@@ -86,9 +86,9 @@ Obj HTAdd_TreeHash_C(Obj self, Obj ht, Obj x, Obj v)
 
     /* Finally add value into tree: */
     if (v != True) {
-        r = AVLAdd_C(self,t,x,v);
+        r = DS_AVLAdd_C(self,t,x,v);
     } else {
-        r = AVLAdd_C(self,t,x,True);
+        r = DS_AVLAdd_C(self,t,x,True);
     }
 
     if (r != Fail) {
@@ -98,7 +98,7 @@ Obj HTAdd_TreeHash_C(Obj self, Obj ht, Obj x, Obj v)
         return Fail;
 }
 
-Obj HTValue_TreeHash_C(Obj self, Obj ht, Obj x)
+Obj DS_HTValue_TreeHash_C(Obj self, Obj ht, Obj x)
 {
     Obj els;
     Obj vals;
@@ -124,10 +124,10 @@ Obj HTValue_TreeHash_C(Obj self, Obj ht, Obj x)
     if (t == 0L)  /* Unbound entry! */
         return Fail;
 
-    /* Now check whether it is an AVLTree or not: */
+    /* Now check whether it is an DS_AVLTree or not: */
     if (TNUM_OBJ(t) != T_POSOBJ ||
-        (TYPE_POSOBJ(t) != AVLTreeType &&
-         TYPE_POSOBJ(t) != AVLTreeTypeMutable)) {
+        (TYPE_POSOBJ(t) != DS_AVLTreeType &&
+         TYPE_POSOBJ(t) != DS_AVLTreeTypeMutable)) {
         if (CALL_2ARGS(ElmPRec(ht,RNam_cmpfunc),x,t) == INTOBJ_INT(0)) {
             if (LEN_PLIST(vals) >= h && ELM_PLIST(vals,h) != 0L)
                 return ELM_PLIST(vals,h);
@@ -137,12 +137,12 @@ Obj HTValue_TreeHash_C(Obj self, Obj ht, Obj x)
         return Fail;
     }
 
-    h = AVLFind(t,x);
+    h = DS_AVLFind(t,x);
     if (h == 0) return Fail;
-    return AVLValue(t,h);
+    return DS_AVLValue(t,h);
 }
 
-Obj HTDelete_TreeHash_C(Obj self, Obj ht, Obj x)
+Obj DS_HTDelete_TreeHash_C(Obj self, Obj ht, Obj x)
 {
     Obj els;
     Obj vals;
@@ -164,10 +164,10 @@ Obj HTDelete_TreeHash_C(Obj self, Obj ht, Obj x)
     if (t == 0L)  /* Unbound entry! */
         return Fail;
 
-    /* Now check whether it is an AVLTree or not: */
+    /* Now check whether it is an DS_AVLTree or not: */
     if (TNUM_OBJ(t) != T_POSOBJ ||
-        (TYPE_POSOBJ(t) != AVLTreeType &&
-         TYPE_POSOBJ(t) != AVLTreeTypeMutable)) {
+        (TYPE_POSOBJ(t) != DS_AVLTreeType &&
+         TYPE_POSOBJ(t) != DS_AVLTreeTypeMutable)) {
         if (CALL_2ARGS(ElmPRec(ht,RNam_cmpfunc),x,t) == INTOBJ_INT(0)) {
             if (LEN_PLIST(vals) >= h && ELM_PLIST(vals,h) != 0L) {
                 v = ELM_PLIST(vals,h);
@@ -180,14 +180,14 @@ Obj HTDelete_TreeHash_C(Obj self, Obj ht, Obj x)
         return Fail;
     }
 
-    v = AVLDelete_C(self,t,x);
+    v = DS_AVLDelete_C(self,t,x);
     if (v != Fail)
         AssPRec(ht,RNam_nr,INTOBJ_INT(INT_INTOBJ(ElmPRec(ht,RNam_nr))-1));
 
     return v;
 }
 
-Obj HTUpdate_TreeHash_C(Obj self, Obj ht, Obj x, Obj v)
+Obj DS_HTUpdate_TreeHash_C(Obj self, Obj ht, Obj x, Obj v)
 {
     Obj els;
     Obj vals;
@@ -209,10 +209,10 @@ Obj HTUpdate_TreeHash_C(Obj self, Obj ht, Obj x, Obj v)
     if (t == 0L)  /* Unbound entry! */
         return Fail;
 
-    /* Now check whether it is an AVLTree or not: */
+    /* Now check whether it is an DS_AVLTree or not: */
     if (TNUM_OBJ(t) != T_POSOBJ ||
-        (TYPE_POSOBJ(t) != AVLTreeType &&
-         TYPE_POSOBJ(t) != AVLTreeTypeMutable)) {
+        (TYPE_POSOBJ(t) != DS_AVLTreeType &&
+         TYPE_POSOBJ(t) != DS_AVLTreeTypeMutable)) {
         if (CALL_2ARGS(ElmPRec(ht,RNam_cmpfunc),x,t) == INTOBJ_INT(0)) {
             if (LEN_PLIST(vals) >= h && ELM_PLIST(vals,h) != 0L) {
                 old = ELM_PLIST(vals,h);
@@ -224,10 +224,10 @@ Obj HTUpdate_TreeHash_C(Obj self, Obj ht, Obj x, Obj v)
         return Fail;
     }
 
-    h = AVLFind(t,x);
+    h = DS_AVLFind(t,x);
     if (h == 0) return Fail;
-    old = AVLValue(t,h);
-    SetAVLValue(t,h,v);
+    old = DS_AVLValue(t,h);
+    SetDS_AVLValue(t,h,v);
     return old;
 }
 
@@ -236,10 +236,10 @@ Obj HTUpdate_TreeHash_C(Obj self, Obj ht, Obj x, Obj v)
 // Submodule declaration
 //
 static StructGVarFunc GVarFuncs[] = {
-    GVARFUNC("hashtable.c", HTAdd_TreeHash_C, 3, "treehash, x, v"),
-    GVARFUNC("hashtable.c", HTValue_TreeHash_C, 2, "treehash, x"),
-    GVARFUNC("hashtable.c", HTDelete_TreeHash_C, 2, "treehash, x"),
-    GVARFUNC("hashtable.c", HTUpdate_TreeHash_C, 3, "treehash, x, v"),
+    GVARFUNC("hashtable.c", DS_HTAdd_TreeHash_C, 3, "treehash, x, v"),
+    GVARFUNC("hashtable.c", DS_HTValue_TreeHash_C, 2, "treehash, x"),
+    GVARFUNC("hashtable.c", DS_HTDelete_TreeHash_C, 2, "treehash, x"),
+    GVARFUNC("hashtable.c", DS_HTUpdate_TreeHash_C, 3, "treehash, x, v"),
 
     { 0 }
 };
@@ -247,7 +247,7 @@ static StructGVarFunc GVarFuncs[] = {
 static Int InitKernel(void)
 {
     InitHdlrFuncsFromTable( GVarFuncs );
-    ImportFuncFromLibrary( "HTGrow", &HTGrow );
+    ImportFuncFromLibrary( "DS_HTGrow", &DS_HTGrow );
     return 0;
 }
 
@@ -276,7 +276,7 @@ static Int InitLibrary(void)
     return PostRestore();
 }
 
-struct DatastructuresModule HashTableModule = {
+struct DatastructuresModule DS_HashTableModule = {
     .initKernel  = InitKernel,
     .initLibrary = InitLibrary,
     .postRestore = PostRestore,

--- a/src/hashtable-avl.h
+++ b/src/hashtable-avl.h
@@ -11,6 +11,6 @@
 
 #include "datastructures.h"
 
-extern struct DatastructuresModule HashTableModule;
+extern struct DatastructuresModule DS_HashTableModule;
 
 #endif

--- a/tst/basictests/avl.tst
+++ b/tst/basictests/avl.tst
@@ -2,7 +2,7 @@ gap> START_TEST("datastructures package: avl.tst");
 
 #
 gap> n := 10000;;
-gap> t := AVLTree();;
+gap> t := DS_AVLTree();;
 gap> valList := EmptyPlist(n);;
 gap> valSet := EmptyPlist(n);;
 gap> missingSet := Set([]);;
@@ -20,32 +20,32 @@ gap> for i in [1..n] do
 >    AddSet(missingSet, x);
 > od;
 gap> for i in [1..n] do
->    AVLAdd(t,valList[i],i);
+>    DS_AVLAdd(t,valList[i],i);
 > od;
-gap> List([1..n], i -> AVLLookup(t, valList[i])) = [1..n];
+gap> List([1..n], i -> DS_AVLLookup(t, valList[i])) = [1..n];
 true
-gap> ForAll([1..n], i -> AVLLookup(t, missingSet[i]) = fail);
+gap> ForAll([1..n], i -> DS_AVLLookup(t, missingSet[i]) = fail);
 true
-gap> List([1..n], i -> AVLValue(t, AVLFind(t, valList[i]))) = [1..n];
+gap> List([1..n], i -> DS_AVLValue(t, DS_AVLFind(t, valList[i]))) = [1..n];
 true
-gap> ForAll([1..n], i -> AVLFind(t, missingSet[i]) = fail);
+gap> ForAll([1..n], i -> DS_AVLFind(t, missingSet[i]) = fail);
 true
-gap> lll := List([1..n], i -> AVLIndexLookup(t, i));;
+gap> lll := List([1..n], i -> DS_AVLIndexLookup(t, i));;
 gap> lll = List(valSet, x -> Position(valList, x));
 true
 gap> llll := EmptyPlist(n);;
 gap> for i in [n,n-1..1] do
->    llll[i] := AVLIndex(t,i);
+>    llll[i] := DS_AVLIndex(t,i);
 > od;;
 gap> llll = valSet;
 true
 gap> for i in [1..n] do
->    AVLDelete(t,valList[i]);
->    AVLAdd(t,valList[i],i);
+>    DS_AVLDelete(t,valList[i]);
+>    DS_AVLAdd(t,valList[i],i);
 > od;
-gap> AVLTest(t).ok;
+gap> DS_AVLTest(t).ok;
 true
-gap> ss := AVLToList(t);;
+gap> ss := DS_AVLToList(t);;
 gap> List(ss, x -> x[1]) = valSet;
 true
 

--- a/tst/hash-plain.tst
+++ b/tst/hash-plain.tst
@@ -6,17 +6,17 @@ gap> G := GL(3,5);; v := One(G)[1];;
 gap> orb := Orbit(G,v);;
 
 #
-gap> ht := HTCreate(v, rec(hashlen := 1000));
+gap> ht := DS_HTCreate(v, rec(hashlen := 1000));
 <hash table obj len=1000 used=0 colls=0 accs=0 (can grow)>
 
 #
 gap> for i in [1..Length(orb)] do
->     HTAdd(ht, orb[i], i);
+>     DS_HTAdd(ht, orb[i], i);
 > od;
 
 #
 gap> for i in [1..Length(orb)] do
->     if HTValue(ht, orb[i]) <> i then
+>     if DS_HTValue(ht, orb[i]) <> i then
 >         Error("lookup in orb failed at ", i);
 >     fi;
 > od;
@@ -24,12 +24,12 @@ gap> for i in [1..Length(orb)] do
 #
 gap> orb2 := Set(orb);;
 gap> for i in [1..Length(orb2)] do
->     HTUpdate(ht, orb2[i], i);
+>     DS_HTUpdate(ht, orb2[i], i);
 > od;
 
 #
 gap> for i in [1..Length(orb2)] do
->     if HTValue(ht, orb2[i]) <> i then
+>     if DS_HTValue(ht, orb2[i]) <> i then
 >         Error("lookup in orb2 failed at ", i);
 >     fi;
 > od;

--- a/tst/hash-tree.tst
+++ b/tst/hash-tree.tst
@@ -6,17 +6,17 @@ gap> G := GL(3,5);; v := One(G)[1];;
 gap> orb := Orbit(G,v);;
 
 #
-gap> ht := HTCreate(v, rec(treehashsize := 1000));
+gap> ht := DS_HTCreate(v, rec(treehashsize := 1000));
 <tree hash table len=1000 used=0 colls=0 accs=0>
 
 #
 gap> for i in [1..Length(orb)] do
->     HTAdd(ht, orb[i], i);
+>     DS_HTAdd(ht, orb[i], i);
 > od;
 
 #
 gap> for i in [1..Length(orb)] do
->     if HTValue(ht, orb[i]) <> i then
+>     if DS_HTValue(ht, orb[i]) <> i then
 >         Error("lookup failed for ", orb[i]);
 >     fi;
 > od;
@@ -24,12 +24,12 @@ gap> for i in [1..Length(orb)] do
 #
 gap> orb2 := Set(orb);;
 gap> for i in [1..Length(orb2)] do
->     HTUpdate(ht, orb2[i], i);
+>     DS_HTUpdate(ht, orb2[i], i);
 > od;
 
 #
 gap> for i in [1..Length(orb2)] do
->     if HTValue(ht, orb2[i]) <> i then
+>     if DS_HTValue(ht, orb2[i]) <> i then
 >         Error("lookup in orb2 failed at ", i);
 >     fi;
 > od;


### PR DESCRIPTION
This PR renames all components that are also part of ORB to avoid name clashes. The rationale is that we want to experiment with datastructures and interfaces without breaking ORB, so we don't want to make ORB dependent on datastructures.
