### PR TITLE
Adding a binary heap (WIP)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,8 @@ lib_LTLIBRARIES = datastructures.la
 datastructures_la_SOURCES = \
     src/avltree.c \
     src/avltree.h \
+    src/binaryheap.c \
+    src/binaryheap.h \
     src/datastructures.c \
     src/hashtable-avl.c \
     src/hashtable-avl.h

--- a/bench-heap.g
+++ b/bench-heap.g
@@ -1,0 +1,117 @@
+LoadPackage("datastructures");
+
+# Tests for the heap implementation.
+# TODO: Rewrite using the UnitTests package
+
+PCQL_Heap_Create:=function(vals)
+    local h, x;
+    h := PairingHeap();
+    for x in vals do
+        # We use -x as key because we want find/remove MAX but
+        # datastructures provides find/remove MIN.
+        PairingHeapPush(h,-x,x);
+    od;
+    return h;
+end;
+
+PCQL_Heap_IsValid := ReturnTrue;
+
+PCQL_Heap_FindMax := heap -> PairingHeapPeek(heap)[2];
+
+PCQL_Heap_RemoveMax := heap -> PairingHeapPop(heap)[2];
+
+PCQL_Heap_IsEmpty := heap -> heap![1] = 0;
+
+PCQL_Heap_Length := heap -> heap![1];
+
+fails := 0;
+successes := 0;
+
+TestHeap := function(vals)
+    local heap, x, i;
+    Print("Testing heap code with ", Length(vals), " elements\n");
+    heap := PCQL_Heap_Create(vals);
+    if not PCQL_Heap_IsValid(heap) then
+        fails := fails + 1;
+        Print("  FAILURE: newly created heap is invalid\n");
+        return;
+    fi;
+
+    Sort(vals, function(a,b) return a>b; end);
+    for i in [1..Length(vals)] do
+        x := PCQL_Heap_FindMax(heap);
+        if x <> vals[i] then
+            fails := fails + 1;
+            Print("  FAILURE in FindMax at sorted position ", i,
+                " (expected ", vals[i], " but got ", x, ")\n");
+            return;
+        fi;
+        x := PCQL_Heap_RemoveMax(heap);
+        if x <> vals[i] then
+            fails := fails + 1;
+            Print("  FAILURE in RemoveMax at sorted position ", i,
+                " (expected ", vals[i], " but got ", x, ")\n");
+            return;
+        fi;
+        if not PCQL_Heap_IsValid(heap) then
+            fails := fails + 1;
+            Print("  FAILURE: heap invalid\n");
+            return;
+        fi;
+    od;
+    if not PCQL_Heap_IsEmpty(heap) then
+        fails := fails + 1;
+        Print("  FAILURE: heap should be empty but isn't\n");
+        return;
+    fi;
+    successes := successes + 1;
+end;
+
+#TestHeap( [ 17, 3, 5 ] );
+
+TestHeap( [] );
+
+for n in [1..20] do
+    vals := List([1..n], i -> Random([1..50]));
+    TestHeap(vals);
+od;
+
+Print("Of ", fails + successes, " tests, ", fails, " failed and ", successes, " succeeded.\n");
+
+GASMAN("collect");
+GASMAN("collect");
+
+RunHeapTests := function(len)
+    local vals, t, heap, i, x;
+
+    vals := List([1..len], i -> Random([1..2^27]));;
+    t := Runtime();;
+    heap := PCQL_Heap_Create(vals);;
+    Print("Creating heap: ", (Runtime() - t)/1000.0, " seconds\n");
+    
+    if PCQL_Heap_Length(heap) <> Length(vals) then
+        Error("wrong length");
+    fi;
+
+    t := Runtime();;
+    Sort(vals, function(a,b) return a>b; end);
+    Print("Sorting plist: ", (Runtime() - t)/1000.0, " seconds\n");
+
+    t := Runtime();;
+    for i in [1..Length(vals)] do
+        x := PCQL_Heap_RemoveMax(heap);
+        if x <> vals[i] then
+            Error("oops");
+        fi;
+    od;
+    Print("Reading heap: ", (Runtime() - t)/1000.0, " seconds\n");
+end;
+
+#if false then
+#PCQL_Heap_Insert:=_PCQL_Heap_Insert_GAP;
+#PCQL_Heap_ReplaceMax:=_PCQL_Heap_ReplaceMax_GAP;
+#PCQL_Heap_Insert:=_PCQL_Heap_Insert_C;
+#PCQL_Heap_ReplaceMax:=_PCQL_Heap_ReplaceMax_C;
+
+RunHeapTests(2^20);
+#fi;

--- a/gap/binaryheap.gd
+++ b/gap/binaryheap.gd
@@ -1,0 +1,16 @@
+# DeclareCategory("IsHeap", IsCollection);
+# BindGlobal( "HeapFamily", NewFamily("HeapFamily") );
+#
+# DeclareConstructor("NewHeap", [IsHeap, IsObject, IsObject, IsObject]);
+#
+# # Inserts a new key into the heap.
+# DeclareOperation("Push", [IsHeap, IsObject, IsObject]);
+# # Peek the item with the maximal key
+# DeclareOperation("Peek", [IsHeap]);
+# # Get the the item with the maximal key
+# DeclareOperation("Pop", [IsHeap]);
+# # Merge two heaps (of the same type)
+# DeclareOperation("Merge", [IsHeap, IsHeap]);
+#
+# #
+# DeclareAttribute("Size", IsHeap);

--- a/gap/binaryheap.gi
+++ b/gap/binaryheap.gi
@@ -1,0 +1,156 @@
+#
+# This file contains a GAP implementation of a binary max-heap.
+#
+# Currently, a binary heap is a record with the following member:
+# - data: the actual heap, represented as a GAP list
+# - isLess: a function comparing two heap elements, by default \<
+#
+# Most functions also have a C implementation. If available, we
+# use the C function, otherwise (e.g. if the package has not been
+# compiled) we fall back to the GAP implementation.
+#
+#
+#
+# Some hints for writing efficient binary heap implementations:
+# <http://stackoverflow.com/questions/6531543>
+#
+# Note that while there are other heap datastructures which in
+# theory have better asymptotical behavior than binary heaps, in
+# real-world applications, a well-tunes binary heap often
+# outperforms other heap implementations anyway, due to its
+# simplicity, low constant (in O-notation) and cache friendliness.
+#
+
+BinaryHeap_IsEmpty := function(heap)
+    return Length(heap.data) = 0;
+end;
+
+BinaryHeap_Size := function(heap)
+    return Length(heap.data);
+end;
+
+# TODO: iterator; view/print; Random; ...
+# DecreaseKey ?
+# Merge ?
+
+
+# Alternative name: Peek
+BinaryHeap_FindMax := function(heap)
+    if Length(heap.data) = 0 then return fail; fi; # alternative: error
+    return heap.data[1];
+end;
+
+_BinaryHeap_BubbleUp := function(data, isLess, i, elm)
+    local parent;
+    while i > 1 do
+        parent := QuoInt(i, 2);
+        if not isLess(data[parent], elm) then
+            break;
+        fi;
+        data[i] := data[parent];
+        i := parent;
+    od;
+    data[i] := elm;
+end;
+
+# Alternative name: Push / Add
+_BinaryHeap_Insert_GAP := function(heap, elm)
+    _BinaryHeap_BubbleUp(heap.data, heap.isLess, Length(heap.data) + 1, elm);
+end;
+
+if IsBound(_BinaryHeap_Insert_C) then
+	BinaryHeap_Insert := _BinaryHeap_Insert_C;
+else
+	BinaryHeap_Insert := _BinaryHeap_Insert_GAP;
+fi;
+
+_BinaryHeap_ReplaceMax_GAP := function(heap, elm)
+    local data, isLess, i, left, right;
+    data := heap.data;
+    isLess := heap.isLess;
+    i := 1;
+    # treat the head slot as a hole that we bubble down
+    while 2 * i <= Length(data) do
+        left := 2 * i;
+        right := left + 1;
+        if right > Length(data) or isLess(data[right], data[left]) then
+            data[i] := data[left];
+            i := left;
+        else
+            data[i] := data[right];
+            i := right;
+        fi;
+    od;
+
+    # Insert the new element into the hole bubble it up.
+    _BinaryHeap_BubbleUp(heap.data, heap.isLess, i, elm);
+end;
+
+if IsBound(_BinaryHeap_ReplaceMax_C) then
+	BinaryHeap_ReplaceMax := _BinaryHeap_ReplaceMax_C;
+else
+	BinaryHeap_ReplaceMax := _BinaryHeap_ReplaceMax_GAP;
+fi;
+
+# Alternative name: Pop / Remove
+BinaryHeap_RemoveMax := function(heap)
+    local val, data;
+    data := heap.data;
+
+    if Length(data) = 0 then
+        return fail; # alternative: error
+    elif Length(data) = 1 then
+        return Remove(data);
+    fi;
+
+    val := data[1];
+    BinaryHeap_ReplaceMax(heap, Remove(data));
+    return val;
+end;
+
+
+BinaryHeap_IsValid := function(heap)
+    local data, i, left, right;
+    data := heap.data;
+    for i in [1..Length(data)] do
+        left := 2 * i;
+        right := left + 1;
+        if left <= Length(data) and heap.isLess(data[i], data[left]) then
+            Print("data[",i,"] = ",data[i], " < ",data[left]," = data[",left,"]\n");
+            return false;
+        fi;
+        if right <= Length(data) and heap.isLess(data[i], data[right]) then
+            Print("data[",i,"] = ",data[i], " < ",data[right]," = data[",right,"]\n");
+            return false;
+        fi;
+    od;
+    return true;
+end;
+
+BinaryHeap_Create := function(arg)
+    local isLess, data, heap, x;
+
+    isLess := \<;
+    data := [];
+
+    if Length(arg) = 1 then
+        if IsFunction(arg[1]) then
+            isLess := arg[1];
+        else
+            data := arg[1];
+        fi;
+    elif Length(arg) = 2 then
+        isLess := arg[1];
+        data := arg[2];
+    elif Length(arg) > 2 then
+        Error("Wrong number of arguments");
+    fi;
+
+    heap := rec( isLess := isLess, data := [] );
+    for x in data do
+        BinaryHeap_Insert(heap, x);
+    od;
+    return heap;
+end;
+
+

--- a/init.g
+++ b/init.g
@@ -37,6 +37,9 @@ ReadPackage("datastructures", "gap/hash.gd");
 ReadPackage("datastructures", "gap/cache.gd");
 ReadPackage("datastructures", "gap/dllist.gd");
 
+# Binary heap
+ReadPackage("datastructures", "gap/binaryheap.gi");
+
 # Pairing Heaps
 ReadPackage("datastructures", "gap/pairingheap.gd");
 

--- a/read.g
+++ b/read.g
@@ -19,6 +19,7 @@ ReadPackage("datastructures", "gap/hash.gi");
 ReadPackage("datastructures", "gap/cache.gi");
 ReadPackage("datastructures", "gap/dllist.gi");
 
+ReadPackage("datastructures", "gap/binaryheap.gi");
 ReadPackage("datastructures", "gap/pairingheap.gi");
 
 

--- a/src/binaryheap.c
+++ b/src/binaryheap.c
@@ -1,0 +1,152 @@
+/*
+ * Datastructures: GAP package providing common datastructures.
+ * Licensed under the GPL 2 or later.
+ *
+ * Implementation of a binary heap.
+ *
+ * Binary heaps are of course pretty standard data structures.
+ * However, a few design choices are possible. The implementation
+ * below has been influenced by this StackOverflow answer:
+ *   <https://stackoverflow.com/questions/6531543>
+ */
+
+#include "binaryheap.h"
+
+typedef Obj (* GVarFuncType)(/*arguments*/);
+
+#define GVAR_FUNC_TABLE_ENTRY(srcfile, name, nparam, params) \
+  {#name, nparam, \
+   params, \
+   (GVarFuncType)name, \
+   srcfile ":Func" #name }
+
+
+static UInt s_isLess_RNam = 0;
+static UInt s_data_RNam = 0;
+
+// "Bubble-up" helper used for insertion: Given a heap <data> (represented by
+// a GAP plist), and a comparison operation <isLess>, insert the <elm> at
+// position <i>. Then compare it to its parent; if they are in the right order,
+// stop; otherwise, swap them, and repeat the process, now with the new parent
+// of our object, until we reach the root.
+//
+// In practice, we actually only insert the element as the very last step,
+// and don't perform actual swaps. That's a simple optimization.
+//
+// Note that for normal insertions into the heap, as performed by
+// _BinaryHeap_Insert_C(), <i> will be equal to the length of <data> plus 1.
+// But in _BinaryHeap_ReplaceMax_C(), it can be less than that.
+static void _BinaryHeap_BubbleUp_C(Obj data, Obj isLess, Int i, Obj elm) {
+  if (LEN_PLIST(data) < i) {
+    GROW_PLIST(data, i);
+    SET_LEN_PLIST(data, i);
+  }
+
+  while (i > 1) {
+    Obj parent = ELM_PLIST(data, i >> 1);
+    if (False == CALL_2ARGS(isLess, parent, elm))
+      break;
+    SET_ELM_PLIST(data, i, parent);
+    i >>= 1;
+  }
+
+  SET_ELM_PLIST(data, i, elm);
+  CHANGED_BAG(data);
+}
+
+// "Bubble down" helper used for extraction: Given a heap <data> (represented
+// by a GAP plist), and a comparison operation <isLess>, start with a "hole"
+// or "bubble" at position <i>, and push it down through the heap.
+static Int _BinaryHeap_BubbleDown_C(Obj data, Obj isLess, Int i) {
+  Int len = LEN_PLIST(data);
+  while (2 * i <= len) {
+    // get positions of the children of <i>
+    Int left = 2 * i;
+    Int right = 2 * i + 1;
+
+    // if there is no right child, move the left child up
+    // and exit
+    if (right > len) {
+      SET_ELM_PLIST(data, i, ELM_PLIST(data, left));
+      break;    // next iteration would stop anyway
+    }
+
+    // otherwise, compare left and right child, and move the larger one up
+    Obj leftObj = ELM_PLIST(data, left);
+    Obj rightObj = ELM_PLIST(data, right);
+    if (True == CALL_2ARGS(isLess, rightObj, leftObj)) {
+      SET_ELM_PLIST(data, i, leftObj);
+      i = left;
+    } else {
+      SET_ELM_PLIST(data, i, rightObj);
+      i = right;
+    }
+  }
+
+  return i;
+}
+
+Obj _BinaryHeap_Insert_C(Obj self, Obj heap, Obj elm) {
+  GAP_ASSERT(IS_PREC_REP(heap));
+  Obj data = ElmPRec(heap, s_data_RNam);
+  Obj isLess = ElmPRec(heap, s_isLess_RNam);
+
+  if (!IS_DENSE_PLIST(data))
+    ErrorQuit("<data> is not a dense plist", 0L, 0L);
+
+  Int len = LEN_PLIST(data);
+  if (len == 0)
+    s(data, 1, elm);
+  else
+    _BinaryHeap_BubbleUp_C(data, isLess, len + 1, elm);
+
+  return 0;
+}
+
+Obj _BinaryHeap_ReplaceMax_C(Obj self, Obj heap, Obj elm) {
+  GAP_ASSERT(IS_PREC_REP(heap));
+  Obj data = ElmPRec(heap, s_data_RNam);
+  Obj isLess = ElmPRec(heap, s_isLess_RNam);
+
+  if (!IS_DENSE_PLIST(data))
+    ErrorQuit("<data> is not a dense plist", 0L, 0L);
+
+  // treat the head slot as a hole that we move down into a leaf
+  Int i = _BinaryHeap_BubbleDown_C(data, isLess, 1);
+
+  // insert the new element into the leaf-hole and move it up
+  _BinaryHeap_BubbleUp_C(data, isLess, i, elm);
+
+  return 0;
+}
+
+static StructGVarFunc GVarFuncs[] = {
+    GVAR_FUNC_TABLE_ENTRY("binaryheap.c", _BinaryHeap_Insert_C, 2, "heap, elm"),
+    GVAR_FUNC_TABLE_ENTRY("binaryheap.c", _BinaryHeap_ReplaceMax_C, 2,
+                          "heap, elm"),
+    {0}
+};
+
+static Int InitKernel(void) {
+  InitHdlrFuncsFromTable(GVarFuncs);
+  return 0;
+}
+
+static Int PostRestore(void) {
+  s_isLess_RNam = RNamName("isLess");
+  s_data_RNam = RNamName("data");
+  return 0;
+}
+
+static Int InitLibrary(void) {
+  InitGVarFuncsFromTable(GVarFuncs);
+
+  // make sure PostRestore() is always run when we are loaded
+  return PostRestore();
+}
+
+struct DatastructuresModule BinaryHeapModule = {
+    .initKernel = InitKernel,
+    .initLibrary = InitLibrary,
+    .postRestore = PostRestore,
+};

--- a/src/binaryheap.h
+++ b/src/binaryheap.h
@@ -1,0 +1,13 @@
+/*
+ * Datastructures: GAP package providing common datastructures.
+ * Licensed under the GPL 2 or later.
+ */
+
+#ifndef BINARY_HEAP_H
+#define BINARY_HEAP_H
+
+#include "datastructures.h"
+
+extern struct DatastructuresModule BinaryHeapModule;
+
+#endif

--- a/src/datastructures.c
+++ b/src/datastructures.c
@@ -6,6 +6,7 @@
 #include "datastructures.h"
 
 #include "avltree.h"
+#include "binaryheap.h"
 #include "hashtable-avl.h"
 
 
@@ -13,6 +14,7 @@
 static struct DatastructuresModule *submodules[] = {
     &DS_AVLTreeModule,
     &DS_HashTableModule,
+    &BinaryHeapModule,
 };
 
 #define ITERATE_SUBMODULE(func) \

--- a/tst/binaryheap.tst
+++ b/tst/binaryheap.tst
@@ -1,0 +1,38 @@
+# Test the binary heap implementation
+gap> START_TEST("datastructures package: binaryheap.tst");
+
+# Compute some test data
+gap> G := GL(3,5);; v := One(G)[1];;
+gap> orb := Orbit(G,v);;
+
+#
+gap> ht := HTCreate(v, rec(treehashsize := 1000));
+<tree hash table len=1000 used=0 colls=0 accs=0>
+
+#
+gap> for i in [1..Length(orb)] do
+>     HTAdd(ht, orb[i], i);
+> od;
+
+#
+gap> for i in [1..Length(orb)] do
+>     if HTValue(ht, orb[i]) <> i then
+>         Error("lookup failed for ", orb[i]);
+>     fi;
+> od;
+
+#
+gap> orb2 := Set(orb);;
+gap> for i in [1..Length(orb2)] do
+>     HTUpdate(ht, orb2[i], i);
+> od;
+
+#
+gap> for i in [1..Length(orb2)] do
+>     if HTValue(ht, orb2[i]) <> i then
+>         Error("lookup in orb2 failed at ", i);
+>     fi;
+> od;
+
+#
+gap> STOP_TEST( "datastructures package: binaryheap.tst", 1);


### PR DESCRIPTION
This PR adds just the binary heap from PR #15. Things I'd like to do with it before merge (or after...)

* should its functions also get a `DT_` resp. `_DT_` prefix?
* when I wrote it, it was convenient to represent the heap as a record, as my prototype was written in GAP, which I then gradually converted to C. Perhaps we'd be better off rewriting this into a position object, though...
* There is a simple optimization I'd want to consider: if the user does not specify an `isLess`, or specifies `LT` resp. `\<`;  then detect that and do *not* invoke `CALL_2ARGS(isLess, ELM_PLIST(data, right), ELM_PLIST(data, left))`, instead use `LtFuncs`, for better performance.
* perhaps also use C++ templates for optimizations...?
* add an efficient _BinaryHeap_Create_C function which takes a list of objects and adds them all into the heap, which runs in O(n) instead of the native "insert elements using _BinaryHeap_Insert_C" which runs in O(n*log(n)). Pseudo-code from Wikipedia:
```
Build-Max-Heap[4] (A):
 heap_length[A] <- length[A]
   for i <- floor(length[A]/2) downto 1 do
    Max-Heapify(A, i)
```
and from GAP kernel's HEAP_SORT_PLIST:
```
  UInt len = LEN_LIST(list);
  UInt i;
  for (i = (len/2); i > 0 ; i--)
    BubbleDown(list, i, len);
```