### PR TITLE
Reimplement merge_pairs in C

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,8 +10,12 @@ datastructures_la_SOURCES = \
     src/binaryheap.h \
     src/hashmap.c \
     src/hashmap.h \
+    src/hashfunctions.c \
+    src/hashfunctions.h \
+    src/pairingheap.c \
+    src/pairingheap.h \
     src/datastructures.c \
-    src/hashfunctions.c
+    src/datastructures.h
 
 datastructures_la_CPPFLAGS = $(GAP_CPPFLAGS) -DCONFIG_H
 # Note that the latter is only for GAP 4.4.12

--- a/gap/pairingheap.gi
+++ b/gap/pairingheap.gi
@@ -77,60 +77,13 @@ end);
 
 InstallGlobalFunction(PairingHeapPop,
 function(heap)
-    local res, merge_pairs, meld;
-
-    meld := function(isLess, x, y)
-        if isLess(y[1],x[1]) then
-            Add(x[3], y);
-            x[2] := x[2] + y[2];
-            return x;
-        else
-            Add(y[3], x);
-            y[2] := x[2] + y[2];
-            return y;
-        fi;
-    end;
-
-    merge_pairs := function(isLess, heaps)
-        local l, res, tmp, k, s, i, r, old_s;
-
-        l := Length(heaps);
-
-        if l = 0 then
-            return [0,0,0];
-        elif l = 1 then
-            return heaps[1];
-        else
-            res := heaps;
-            k := l;
-            s := 1;
-
-            while k > 1 do
-                r := RemInt(k, 2);
-                k := QuoInt(k, 2);
-                old_s := s;
-                s := 2*s;
-
-                for i in [s, 2*s .. k*s] do
-                    res[i] := meld(isLess, res[i - old_s], res[i]);
-                od;
-                if r = 1 then
-                    i := i + s;
-                    res[i] := res[i - old_s];
-                    k := k + 1;
-                fi;
-            od;
-            return res[i];
-        fi;
-    end;
+    local res;
     if heap![1] = 0 then
-        res := fail;
-    else
-        res := heap![3][1];
-        heap![3] := merge_pairs(heap![2], heap![3][3]);
-        heap![1] := heap![3][2];
+        return fail;
     fi;
-
+    res := heap![3][1];
+    heap![3] := DS_merge_pairs(heap![2], heap![3][3]);
+    heap![1] := heap![3][2];
     return res;
 end);
 

--- a/src/datastructures.c
+++ b/src/datastructures.c
@@ -25,6 +25,29 @@ static struct DatastructuresModule * submodules[] = {
         }                                                                    \
     }
 
+void DS_IncrementCounterInPlist(Obj plist, Int pos, Obj inc)
+{
+    Obj val = ELM_PLIST(plist, pos);
+    GAP_ASSERT(IS_INTOBJ(val));
+    GAP_ASSERT(IS_INTOBJ(inc));
+    GAP_ASSERT(inc >= INTOBJ_INT(0));
+    if (!SUM_INTOBJS(val, val, inc))
+        ErrorMayQuit("PANIC: counter overflow", 0, 0);
+    SET_ELM_PLIST(plist, pos, val);
+}
+
+void DS_DecrementCounterInPlist(Obj plist, Int pos, Obj dec)
+{
+    Obj val = ELM_PLIST(plist, pos);
+    GAP_ASSERT(IS_INTOBJ(val));
+    GAP_ASSERT(IS_INTOBJ(dec));
+    GAP_ASSERT(dec >= INTOBJ_INT(0));
+    if (val < dec)
+        ErrorMayQuit("PANIC: counter underflow", 0, 0);
+    DIFF_INTOBJS(val, val, dec);
+    SET_ELM_PLIST(plist, pos, val);
+}
+
 
 static Int InitKernel(StructInitInfo * module)
 {

--- a/src/datastructures.c
+++ b/src/datastructures.c
@@ -6,6 +6,7 @@
 #include "datastructures.h"
 #include "binaryheap.h"
 #include "hashmap.h"
+#include "pairingheap.h"
 
 #include <src/gaputils.h>
 
@@ -13,7 +14,10 @@
 
 // List of datastructure submodules
 static struct DatastructuresModule * submodules[] = {
-    &BinaryHeapModule, &HashmapModule, &HashFunctionsModule,
+    &BinaryHeapModule,
+    &HashFunctionsModule,
+    &HashmapModule,
+    &PairingHeapModule,
 };
 
 #define ITERATE_SUBMODULE(func)                                              \

--- a/src/datastructures.h
+++ b/src/datastructures.h
@@ -46,4 +46,14 @@ struct DatastructuresModule {
     Int (*initLibrary)(void);    // initialise library data structures
 };
 
+
+// The following two helper functions increment resp. decrement the
+// entry <plist> at index <pos> by <inc> resp. <dec>. For this, <inc>
+// resp. <dec> as well as the value being modified must be non-negative
+// immediate integers. If `plist[pos]` were to become negative, or too
+// large to fit into an immediate error, an error is raised.
+extern void DS_IncrementCounterInPlist(Obj plist, Int pos, Obj inc);
+extern void DS_DecrementCounterInPlist(Obj plist, Int pos, Obj dec);
+
+
 #endif

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -26,23 +26,6 @@ enum {
 
 static Obj HashMapType;    // Imported from the library
 
-static void IncrementPlistElm(Obj plist, Int idx)
-{
-    Obj val = ELM_PLIST(plist, idx);
-    if (!SUM_INTOBJS(val, val, INTOBJ_INT(1)))
-        ErrorMayQuit("PANIC: counter overflow in hashmap code", 0, 0);
-    SET_ELM_PLIST(plist, idx, val);
-}
-
-static void DecrementPlistElm(Obj plist, Int idx)
-{
-    Obj val = ELM_PLIST(plist, idx);
-    if (val <= INTOBJ_INT(0))
-        ErrorMayQuit("PANIC: counter underflow in hashmap code", 0, 0);
-    DIFF_INTOBJS(val, val, INTOBJ_INT(1));
-    SET_ELM_PLIST(plist, idx, val);
-}
-
 
 static Int _DS_Hash_Lookup_intern(const Obj ht,
                                   const Obj keys,
@@ -225,7 +208,7 @@ static Obj _DS_Hash_SetOrAccValue(Obj ht, Obj key, Obj val, Obj accufunc)
     Obj old_k = ELM_PLIST(keys, idx);
     if (old_k == Fail) {
         // we are filling a 'deleted' slot
-        DecrementPlistElm(ht, POS_DELETED);
+        DS_DecrementCounterInPlist(ht, POS_DELETED, INTOBJ_INT(1));
     }
 
     if (old_k != Fail && old_k != 0) {
@@ -250,7 +233,7 @@ static Obj _DS_Hash_SetOrAccValue(Obj ht, Obj key, Obj val, Obj accufunc)
             return True;
     }
     else {
-        IncrementPlistElm(ht, POS_USED);
+        DS_IncrementCounterInPlist(ht, POS_USED, INTOBJ_INT(1));
 
         SET_ELM_PLIST(keys, idx, key);
         SET_ELM_PLIST(values, idx, val);
@@ -414,8 +397,8 @@ Obj DS_Hash_Delete(Obj self, Obj ht, Obj key)
     SET_ELM_PLIST(keys, idx, Fail);
     SET_ELM_PLIST(values, idx, 0);
 
-    IncrementPlistElm(ht, POS_DELETED);
-    DecrementPlistElm(ht, POS_USED);
+    DS_IncrementCounterInPlist(ht, POS_DELETED, INTOBJ_INT(1));
+    DS_DecrementCounterInPlist(ht, POS_USED, INTOBJ_INT(1));
 
     return val;
 }

--- a/src/pairingheap.c
+++ b/src/pairingheap.c
@@ -1,0 +1,116 @@
+//
+// Datastructures: GAP package providing common datastructures.
+//
+// Copyright (C) 2015-2017  The datastructures team.
+// For list of the team members, please refer to the COPYRIGHT file.
+//
+// This package is licensed under the GPL 2 or later, please refer
+// to the COPYRIGHT.md and LICENSE files for details.
+//
+
+//
+// Helper function for pairing heaps implementation.
+//
+
+#include "src/compiled.h"
+#include "pairingheap.h"
+
+enum {
+    // the following are indices into a pairing heap object
+
+    HEAP_POS_SIZE = 1,    // node count
+    HEAP_POS_ISLESS,      // comparison function
+    HEAP_POS_NODES,       // nodes
+
+    // the following are indices into the nodes of our pairing heap
+
+    NODE_POS_DATA = 1,    // value of this node
+    NODE_POS_SIZE,        // total number of nodes in the subheaps
+    NODE_POS_SUBHEAPS,    // list of subheaps
+};
+
+Obj DS_merge_pairs(Obj self, Obj isLess, Obj heaps)
+{
+    if (!IS_DENSE_PLIST(heaps))
+        ErrorQuit("<heaps> is not a dense plist", 0L, 0L);
+
+    const UInt len = LEN_PLIST(heaps);
+    Obj res;
+
+    if (len == 0) {
+        res = NEW_PLIST(T_PLIST_CYC, 3);
+        SET_LEN_PLIST(res, 3);
+        SET_ELM_PLIST(res, NODE_POS_DATA, INTOBJ_INT(0));
+        SET_ELM_PLIST(res, NODE_POS_SIZE, INTOBJ_INT(0));
+        SET_ELM_PLIST(res, NODE_POS_SUBHEAPS, INTOBJ_INT(0));
+        return res;
+    }
+
+    if (len == 1) {
+        return ELM_PLIST(heaps, 1);
+    }
+
+    const Int useLt = (isLess == LtOper);
+    res = heaps;
+    UInt k = len;
+    UInt s = 1;
+    UInt i;
+    while (k > 1) {
+        const UInt r = k & 1;
+        const UInt old_s = s;
+        k >>= 1;
+        s <<= 1;
+        for (i = s; i <= k * s; i += s) {
+            GAP_ASSERT(i <= LEN_PLIST(res));
+            Obj x = ELM_PLIST(res, i - old_s);
+            Obj y = ELM_PLIST(res, i);
+            GAP_ASSERT(IS_DENSE_PLIST(x));
+            GAP_ASSERT(IS_DENSE_PLIST(y));
+
+            Obj x_data = ELM_PLIST(x, NODE_POS_DATA);
+            Obj y_data = ELM_PLIST(y, NODE_POS_DATA);
+            if (useLt ? LT(y_data, x_data)
+                      : (True == CALL_2ARGS(isLess, y_data, x_data))) {
+                Obj x_subheaps = ELM_PLIST(x, NODE_POS_SUBHEAPS);
+                AssPlist(x_subheaps, LEN_PLIST(x_subheaps) + 1, y);
+                DS_IncrementCounterInPlist(x, NODE_POS_SIZE,
+                                           ELM_PLIST(y, NODE_POS_SIZE));
+                AssPlist(res, i, x);
+            }
+            else {
+                Obj y_subheaps = ELM_PLIST(y, NODE_POS_SUBHEAPS);
+                AssPlist(y_subheaps, LEN_PLIST(y_subheaps) + 1, x);
+                DS_IncrementCounterInPlist(y, NODE_POS_SIZE,
+                                           ELM_PLIST(x, NODE_POS_SIZE));
+                AssPlist(res, i, y);
+            }
+        }
+        // at this point, i == (k+1)*s
+        if (r == 1) {
+            k++;
+            AssPlist(res, i, ELM_PLIST(res, i - old_s));
+        }
+    }
+    return ELM_PLIST(res, k * s);
+}
+
+static StructGVarFunc GVarFuncs[] = {
+    GVARFUNC(DS_merge_pairs, 2, "isLess, heaps"),
+    { 0 }
+};
+
+static Int InitKernel(void)
+{
+    InitHdlrFuncsFromTable(GVarFuncs);
+    return 0;
+}
+
+static Int InitLibrary(void)
+{
+    InitGVarFuncsFromTable(GVarFuncs);
+    return 0;
+}
+
+struct DatastructuresModule PairingHeapModule = {
+    .initKernel = InitKernel, .initLibrary = InitLibrary,
+};

--- a/src/pairingheap.h
+++ b/src/pairingheap.h
@@ -1,0 +1,22 @@
+//
+// Datastructures: GAP package providing common datastructures.
+//
+// Copyright (C) 2015-2017  The datastructures team.
+// For list of the team members, please refer to the COPYRIGHT file.
+//
+// This package is licensed under the GPL 2 or later, please refer
+// to the COPYRIGHT.md and LICENSE files for details.
+//
+
+//
+// Helper function for pairing heaps implementation.
+//
+
+#ifndef PAIRING_HEAP_H
+#define PAIRING_HEAP_H
+
+#include "datastructures.h"
+
+extern struct DatastructuresModule PairingHeapModule;
+
+#endif


### PR DESCRIPTION
This speeds up the pairing heaps test by a factor of two. E.g.
on my system, I get these TestHeap timings:

Before this commit:
```
gap> Benchmark(function() TestHeap(PairingHeap); end, rec(minreps:=10));;
Performed 10 iterations, taking 4443 milliseconds.
average: 444.26 +/- 8.15 (+/- 2%)
median: 444.4478629827499
```
After this commit:
```
gap> Benchmark(function() TestHeap(PairingHeap); end, rec(minreps:=10));;
Performed 10 iterations, taking 1927 milliseconds.
average: 192.74 +/- 3.8 (+/- 2%)
median: 192.5236003994942
```
For reference:
```
Benchmark(function() TestHeap(BinaryHeap); end, rec(minreps:=10));;
Performed 10 iterations, taking 1534 milliseconds.
average: 153.41 +/- 5.09 (+/- 3%)
median: 153.8257709443569
```