### PR TITLE
Add HashSet

### DIFF
--- a/gap/hashset.gd
+++ b/gap/hashset.gd
@@ -1,0 +1,31 @@
+##
+##  Datastructures: GAP package providing common datastructures.
+##
+##  Copyright (C) 2015-2017  The datastructures team.
+##  For list of the team members, please refer to the COPYRIGHT file.
+##
+##  This package is licensed under the GPL 2 or later, please refer
+##  to the COPYRIGHT.md and LICENSE files for details.
+##
+
+#! @Chapter Hashsets
+#!
+#! A hash set stores key-value pairs and allows efficient lookup of keys
+#! by using a hash function.
+#!
+
+
+#! @Section API
+#!
+#! @Description
+#! Category of hashsets
+DeclareCategory( "IsHashSet", IsObject and IsFinite );
+BindGlobal( "HashSetFamily", NewFamily("HashSetFamily") );
+
+DeclareRepresentation( "IsHashSetRep", IsHashSet and IsPositionalObjectRep, [] );
+BindGlobal( "HashSetType", NewType(HashSetFamily, IsHashSetRep and IsMutable) );
+
+
+#! Arguments [hashfunc[, eqfunc]] [capacity]
+#! Create a new hash set.
+DeclareGlobalFunction("HashSet");

--- a/gap/hashset.gi
+++ b/gap/hashset.gi
@@ -9,12 +9,12 @@
 ##
 
 ##
-##  Implementation of a hash map for GAP.
+##  Implementation of a hash set for GAP.
 ##
 
-InstallGlobalFunction(HashMap,
+InstallGlobalFunction(HashSet,
 function(arg...)
-    local hashfunc, eqfunc, capacity;
+    local hashfunc, eqfunc, capacity, res;
 
     hashfunc := HashBasic;
     eqfunc := \=;
@@ -33,47 +33,47 @@ function(arg...)
         Error("Invalid arguments");
     fi;
 
-    return DS_Hash_Create(hashfunc, eqfunc, capacity, false);
+    res := DS_Hash_Create(hashfunc, eqfunc, capacity, true);
+    return res;
 end);
 
-InstallMethod(ViewObj, "for hash maps",
-    [ IsHashMapRep ],
+InstallMethod(ViewObj, "for hashsets",
+    [ IsHashSetRep ],
 function(ht)
-    Print("<hash map obj capacity=",DS_Hash_Capacity(ht),
+    Print("<hash set obj capacity=",DS_Hash_Capacity(ht),
             " used=",DS_Hash_Used(ht),">");
 end);
 
-InstallOtherMethod(\[\],
-    "for a hash map and a key",
-    [ IsHashMapRep, IsObject ],
-    DS_Hash_Value); # TODO: raise an error if key is not bound
-
-InstallOtherMethod(\[\]\:\=,
-    "for a hash map, a key and a value",
-    [ IsHashMapRep, IsObject, IsObject ],
-    DS_Hash_SetValue);
+InstallOtherMethod(AddSet,
+    "for a hash set and a key",
+    [ IsHashSetRep, IsObject ],
+    DS_Hash_AddSet);
 
 InstallOtherMethod( \in,
-    "for a hash map and a key",
-    [ IsObject, IsHashMapRep ],
+    "for a hash set and a key",
+    [ IsObject, IsHashSetRep ],
     {key, ht} -> DS_Hash_Contains(ht, key));
 
-InstallOtherMethod( IsBound\[\],
-    "for a hash map and a key",
-    [ IsHashMapRep, IsObject ],
-    DS_Hash_Contains);
-
-InstallOtherMethod( Unbind\[\],
-    "for a hash map and a key",
-    [ IsHashMapRep, IsObject ],
+InstallOtherMethod( RemoveSet,
+    "for a hash set and a key",
+    [ IsHashSetRep, IsObject ],
     DS_Hash_Delete);
 
 InstallOtherMethod( Size,
-    "for a hash map",
-    [ IsHashMapRep ],
+    "for a hash set",
+    [ IsHashSetRep ],
     ht -> DS_Hash_Used(ht));
 
 InstallOtherMethod( IsEmpty,
-    "for a hash map",
-    [ IsHashMapRep ],
+    "for a hash set",
+    [ IsHashSetRep ],
     ht -> DS_Hash_Used(ht) = 0);
+
+# TODO: things we could implement (but do we want to?)
+# AsSet
+# UnitSet
+# Union
+# Intersection
+# ...
+#
+# But do we really want to???

--- a/init.g
+++ b/init.g
@@ -39,6 +39,9 @@ ReadPackage("datastructures", "gap/pairingheap.gd");
 # hash maps
 ReadPackage("datastructures", "gap/hashmap.gd");
 
+# hash sets
+ReadPackage("datastructures", "gap/hashset.gd");
+
 # Stacks
 ReadPackage("datastructures", "gap/stack.gd");
 

--- a/read.g
+++ b/read.g
@@ -25,6 +25,7 @@ ReadPackage("datastructures", "gap/binaryheap.gi");
 ReadPackage("datastructures", "gap/pairingheap.gi");
 
 ReadPackage("datastructures", "gap/hashmap.gi");
+ReadPackage("datastructures", "gap/hashset.gi");
 
 ReadPackage("datastructures", "gap/stack.gi");
 ReadPackage("datastructures", "gap/hashfunctions.gi");

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -23,6 +23,9 @@ enum {
     POS_KEYS,
     POS_VALUES,
 
+    HASH_SET_SIZE = POS_KEYS + 1,     // one more for type
+    HASH_MAP_SIZE = POS_VALUES + 1,   // one more for type
+
     // various constants used to tweak the hashmap
     PERTURB_SHIFT = 5,
     LOADFACTOR_NUMERATOR = 7,
@@ -30,7 +33,12 @@ enum {
 };
 
 static Obj HashMapType;    // Imported from the library
+static Obj HashSetType;    // Imported from the library
 
+static inline Int IsHashSet(Obj ht)
+{
+    return TYPE_POSOBJ(ht) == HashSetType;
+}
 
 static Int _DS_Hash_Lookup_intern(const Obj ht,
                                   const Obj keys,
@@ -111,7 +119,7 @@ static void _DS_Hash_Resize_intern(Obj ht, Int new_capacity)
     GAP_ASSERT(0 == (new_capacity & (new_capacity - 1)));    // power of 2?
 
     Obj old_keys = ELM_PLIST(ht, POS_KEYS);
-    Obj old_vals = ELM_PLIST(ht, POS_VALUES);
+    Obj old_vals = !IsHashSet(ht) ? ELM_PLIST(ht, POS_VALUES) : 0;
 
     Int old_capacity = LEN_PLIST(old_keys);
     Int old_size = INT_INTOBJ(ELM_PLIST(ht, POS_USED));
@@ -121,8 +129,11 @@ static void _DS_Hash_Resize_intern(Obj ht, Int new_capacity)
     Obj keys = NEW_PLIST(T_PLIST, new_capacity);
     SET_LEN_PLIST(keys, new_capacity);
 
-    Obj values = NEW_PLIST(T_PLIST, new_capacity + 1);
-    SET_LEN_PLIST(values, new_capacity);
+    Obj values = 0;
+    if (old_vals) {
+        values = NEW_PLIST(T_PLIST, new_capacity + 1);
+        SET_LEN_PLIST(values, new_capacity);
+    }
 
     Obj hashfun = ELM_PLIST(ht, POS_HASHFUNC);
     GAP_ASSERT(hashfun && TNUM_OBJ(hashfun) == T_FUNCTION);
@@ -147,10 +158,11 @@ static void _DS_Hash_Resize_intern(Obj ht, Int new_capacity)
 
         Int idx = _DS_Hash_Lookup_intern(ht, keys, k, hash, 0, mask, 1, 1);
 
-        Obj v = ELM_PLIST(old_vals, old_idx);
-
         SET_ELM_PLIST(keys, idx, k);
-        SET_ELM_PLIST(values, idx, v);
+        if (old_vals) {
+            Obj v = ELM_PLIST(old_vals, old_idx);
+            SET_ELM_PLIST(values, idx, v);
+        }
 
         new_size++;
     }
@@ -160,7 +172,8 @@ static void _DS_Hash_Resize_intern(Obj ht, Int new_capacity)
     // known to GASMAN. So it is safe to delay the notification as no objects
     // can be lost.
     CHANGED_BAG(keys);
-    CHANGED_BAG(values);
+    if (values)
+        CHANGED_BAG(values);
 
     if (old_size != new_size)
         ErrorQuit("PANIC: unexpected size change (was %d, now %d)", old_size,
@@ -170,7 +183,8 @@ static void _DS_Hash_Resize_intern(Obj ht, Int new_capacity)
     SET_ELM_PLIST(ht, POS_USED, INTOBJ_INT(new_size));
     SET_ELM_PLIST(ht, POS_DELETED, INTOBJ_INT(0));
     SET_ELM_PLIST(ht, POS_KEYS, keys);
-    SET_ELM_PLIST(ht, POS_VALUES, values);
+    if (values)
+        SET_ELM_PLIST(ht, POS_VALUES, values);
 
     CHANGED_BAG(ht);
 }
@@ -208,7 +222,7 @@ static Obj _DS_Hash_SetOrAccValue(Obj ht, Obj key, Obj val, Obj accufunc)
     Int idx = _DS_Hash_Lookup_MayCreate(ht, key, 1);
 
     Obj keys = ELM_PLIST(ht, POS_KEYS);
-    Obj values = ELM_PLIST(ht, POS_VALUES);
+    Obj values = !IsHashSet(ht) ? ELM_PLIST(ht, POS_VALUES) : 0;
 
     Obj old_k = ELM_PLIST(keys, idx);
     if (old_k == Fail) {
@@ -249,7 +263,48 @@ static Obj _DS_Hash_SetOrAccValue(Obj ht, Obj key, Obj val, Obj accufunc)
     return accufunc ? False : INTOBJ_INT(idx);
 }
 
-static void DS_RequireHash(Obj ht)
+static void _DS_Hash_AddSet(Obj ht, Obj key)
+{
+    if (key == Fail)
+        ErrorQuit("<key> must not be equal to 'fail'", 0L, 0L);
+
+    _DS_GrowIfNecessary(ht);
+
+    Int idx = _DS_Hash_Lookup_MayCreate(ht, key, 1);
+
+    Obj keys = ELM_PLIST(ht, POS_KEYS);
+
+    Obj old_k = ELM_PLIST(keys, idx);
+    if (old_k == Fail) {
+        // we are filling a 'deleted' slot
+        DS_DecrementCounterInPlist(ht, POS_DELETED, INTOBJ_INT(1));
+    }
+
+    if (old_k == Fail || old_k == 0) {
+        DS_IncrementCounterInPlist(ht, POS_USED, INTOBJ_INT(1));
+        SET_ELM_PLIST(keys, idx, key);
+        CHANGED_BAG(keys);
+    }
+}
+
+static void DS_RequireHashMapOrSet(Obj ht)
+{
+    if (TNUM_OBJ(ht) != T_POSOBJ || (TYPE_POSOBJ(ht) != HashMapType
+        && TYPE_POSOBJ(ht) != HashSetType)) {
+        ErrorQuit("<ht> must be a hashmap or hashset (not a %s)",
+                  (Int)TNAM_OBJ(ht), 0);
+    }
+}
+
+static void DS_RequireHashSet(Obj ht)
+{
+    if (TNUM_OBJ(ht) != T_POSOBJ || TYPE_POSOBJ(ht) != HashSetType) {
+        ErrorQuit("<ht> must be a hashset (not a %s)",
+                  (Int)TNAM_OBJ(ht), 0);
+    }
+}
+
+static void DS_RequireHashMap(Obj ht)
 {
     if (TNUM_OBJ(ht) != T_POSOBJ || TYPE_POSOBJ(ht) != HashMapType) {
         ErrorQuit("<ht> must be a hashmap object (not a %s)",
@@ -262,7 +317,7 @@ static void DS_RequireHash(Obj ht)
 // high-level functions, to be called from GAP
 //
 
-Obj DS_Hash_Create(Obj self, Obj hashfunc, Obj eqfunc, Obj capacity)
+Obj DS_Hash_Create(Obj self, Obj hashfunc, Obj eqfunc, Obj capacity, Obj novalues)
 {
     if (TNUM_OBJ(hashfunc) != T_FUNCTION) {
         ErrorQuit("<hashfunc> must be a function (not a %s)",
@@ -276,6 +331,10 @@ Obj DS_Hash_Create(Obj self, Obj hashfunc, Obj eqfunc, Obj capacity)
         ErrorQuit("<capacity> must be a small positive integer (not a %s)",
                   (Int)TNAM_OBJ(capacity), 0);
     }
+    if (novalues != True && novalues != False) {
+        ErrorQuit("<novalues> must be true or false (not a %s)",
+                  (Int)TNAM_OBJ(novalues), 0);
+    }
 
     // convert capacity into integer and round up to a power of 2
     Int requestedCapacity = INT_INTOBJ(capacity);
@@ -283,8 +342,15 @@ Obj DS_Hash_Create(Obj self, Obj hashfunc, Obj eqfunc, Obj capacity)
     while (c < requestedCapacity)
         c <<= 1;
 
-    Obj ht = NewBag(T_POSOBJ, sizeof(Obj) * 7);
-    TYPE_POSOBJ(ht) = HashMapType;
+    Obj ht;
+    if (novalues == True) {
+        ht = NewBag(T_POSOBJ, sizeof(Obj) * HASH_SET_SIZE);
+        SET_TYPE_POSOBJ(ht, HashSetType);
+    }
+    else {
+        ht = NewBag(T_POSOBJ, sizeof(Obj) * HASH_MAP_SIZE);
+        SET_TYPE_POSOBJ(ht, HashMapType);
+    }
 
     SET_ELM_PLIST(ht, POS_HASHFUNC, hashfunc);
     SET_ELM_PLIST(ht, POS_EQFUNC, eqfunc);
@@ -296,48 +362,50 @@ Obj DS_Hash_Create(Obj self, Obj hashfunc, Obj eqfunc, Obj capacity)
     SET_LEN_PLIST(keys, c);
     CHANGED_BAG(ht);
 
-    Obj values = NEW_PLIST(T_PLIST, c);
-    SET_ELM_PLIST(ht, POS_VALUES, values);
-    SET_LEN_PLIST(values, c);
-    CHANGED_BAG(ht);
+    if (novalues == False) {
+        Obj values = NEW_PLIST(T_PLIST, c);
+        SET_ELM_PLIST(ht, POS_VALUES, values);
+        SET_LEN_PLIST(values, c);
+        CHANGED_BAG(ht);
+    }
 
     return ht;
 }
 
 Obj DS_Hash_Capacity(Obj self, Obj ht)
 {
-    DS_RequireHash(ht);
+    DS_RequireHashMapOrSet(ht);
     Obj keys = ELM_PLIST(ht, POS_KEYS);
     return INTOBJ_INT(LEN_PLIST(keys));
 }
 
 Obj DS_Hash_Used(Obj self, Obj ht)
 {
-    DS_RequireHash(ht);
+    DS_RequireHashMapOrSet(ht);
     return ELM_PLIST(ht, POS_USED);
 }
 
 Obj _DS_Hash_Lookup(Obj self, Obj ht, Obj key)
 {
-    DS_RequireHash(ht);
+    DS_RequireHashMapOrSet(ht);
     return INTOBJ_INT(_DS_Hash_Lookup_MayCreate(ht, key, 0));
 }
 
 Obj _DS_Hash_LookupCreate(Obj self, Obj ht, Obj key)
 {
-    DS_RequireHash(ht);
+    DS_RequireHashMapOrSet(ht);
     return INTOBJ_INT(_DS_Hash_Lookup_MayCreate(ht, key, 1));
 }
 
 Obj DS_Hash_Contains(Obj self, Obj ht, Obj key)
 {
-    DS_RequireHash(ht);
+    DS_RequireHashMapOrSet(ht);
     return _DS_Hash_Lookup_MayCreate(ht, key, 0) != 0 ? True : False;
 }
 
 Obj DS_Hash_Value(Obj self, Obj ht, Obj key)
 {
-    DS_RequireHash(ht);
+    DS_RequireHashMap(ht);
     Int idx = _DS_Hash_Lookup_MayCreate(ht, key, 0);
     if (idx == 0)
         return Fail;
@@ -347,7 +415,7 @@ Obj DS_Hash_Value(Obj self, Obj ht, Obj key)
 
 Obj DS_Hash_Reserve(Obj self, Obj ht, Obj new_capacity)
 {
-    DS_RequireHash(ht);
+    DS_RequireHashMapOrSet(ht);
     if (!IS_POS_INTOBJ(new_capacity)) {
         ErrorQuit("<capacity> must be a small positive integer (not a %s)",
                   (Int)TNAM_OBJ(new_capacity), 0);
@@ -374,13 +442,13 @@ Obj DS_Hash_Reserve(Obj self, Obj ht, Obj new_capacity)
 
 Obj DS_Hash_SetValue(Obj self, Obj ht, Obj key, Obj val)
 {
-    DS_RequireHash(ht);
+    DS_RequireHashMap(ht);
     return _DS_Hash_SetOrAccValue(ht, key, val, 0);
 }
 
 Obj DS_Hash_AccumulateValue(Obj self, Obj ht, Obj key, Obj val, Obj accufunc)
 {
-    DS_RequireHash(ht);
+    DS_RequireHashMap(ht);
     if (TNUM_OBJ(accufunc) != T_FUNCTION) {
         ErrorQuit("<accufunc> must be a function (not a %s)",
                   (Int)TNAM_OBJ(accufunc), 0);
@@ -388,19 +456,29 @@ Obj DS_Hash_AccumulateValue(Obj self, Obj ht, Obj key, Obj val, Obj accufunc)
     return _DS_Hash_SetOrAccValue(ht, key, val, accufunc);
 }
 
+Obj DS_Hash_AddSet(Obj self, Obj ht, Obj key)
+{
+    DS_RequireHashSet(ht);
+    _DS_Hash_AddSet(ht, key);
+    return 0;
+}
+
 Obj DS_Hash_Delete(Obj self, Obj ht, Obj key)
 {
-    DS_RequireHash(ht);
+    DS_RequireHashMapOrSet(ht);
     Int idx = _DS_Hash_Lookup_MayCreate(ht, key, 0);
     if (!idx)
         return Fail;
 
     Obj keys = ELM_PLIST(ht, POS_KEYS);
-    Obj values = ELM_PLIST(ht, POS_VALUES);
-    Obj val = ELM_PLIST(values, idx);
-
     SET_ELM_PLIST(keys, idx, Fail);
-    SET_ELM_PLIST(values, idx, 0);
+
+    Obj val = 0;
+    if (!IsHashSet(ht)) {
+        Obj values = ELM_PLIST(ht, POS_VALUES);
+        val = ELM_PLIST(values, idx);
+        SET_ELM_PLIST(values, idx, 0);
+    }
 
     DS_IncrementCounterInPlist(ht, POS_DELETED, INTOBJ_INT(1));
     DS_DecrementCounterInPlist(ht, POS_USED, INTOBJ_INT(1));
@@ -410,7 +488,7 @@ Obj DS_Hash_Delete(Obj self, Obj ht, Obj key)
 
 
 static StructGVarFunc GVarFuncs[] = {
-    GVARFUNC(DS_Hash_Create, 3, "hashfunc, eqfunc, capacity"),
+    GVARFUNC(DS_Hash_Create, 4, "hashfunc, eqfunc, capacity, novalues"),
 
     GVARFUNC(DS_Hash_Capacity, 1, "ht"),
     GVARFUNC(DS_Hash_Used, 1, "ht"),
@@ -423,6 +501,7 @@ static StructGVarFunc GVarFuncs[] = {
     GVARFUNC(DS_Hash_Reserve, 2, "ht, capacity"),
     GVARFUNC(DS_Hash_SetValue, 3, "ht, key, val"),
     GVARFUNC(DS_Hash_AccumulateValue, 4, "ht, key, val, accufunc"),
+    GVARFUNC(DS_Hash_AddSet, 2, "ht, key"),
 
     GVARFUNC(DS_Hash_Delete, 2, "ht, key"),
 
@@ -434,6 +513,7 @@ static Int InitKernel(void)
     InitHdlrFuncsFromTable(GVarFuncs);
 
     ImportGVarFromLibrary("HashMapType", &HashMapType);
+    ImportGVarFromLibrary("HashSetType", &HashSetType);
 
     return 0;
 }

--- a/tst/hashmap.tst
+++ b/tst/hashmap.tst
@@ -170,12 +170,14 @@ gap> HashMap(IdFunc, fail, 2);
 Error, Invalid arguments
 
 # test input validation for DS_Hash_Create
-gap> DS_Hash_Create( fail, \=, 5 );
+gap> DS_Hash_Create( fail, \=, 5, true );
 Error, <hashfunc> must be a function (not a boolean or fail)
-gap> DS_Hash_Create( IdFunc, fail, 5 );
+gap> DS_Hash_Create( IdFunc, fail, 5, true );
 Error, <eqfunc> must be a function (not a boolean or fail)
-gap> DS_Hash_Create( IdFunc, \=, fail );
+gap> DS_Hash_Create( IdFunc, \=, fail, true );
 Error, <capacity> must be a small positive integer (not a boolean or fail)
+gap> DS_Hash_Create( IdFunc, \=, 5, fail );
+Error, <novalues> must be true or false (not a boolean or fail)
 
 # test input validation for DS_Hash_Value
 gap> DS_Hash_Value(fail, 1);
@@ -192,7 +194,7 @@ Error, <ht> must be a hashmap object (not a object (positional))
 
 # test input validation for DS_Hash_Contains
 gap> DS_Hash_Contains(fail, 1);
-Error, <ht> must be a hashmap object (not a boolean or fail)
+Error, <ht> must be a hashmap or hashset (not a boolean or fail)
 gap> DS_Hash_Contains(hashmap, fail);
 Error, <key> must not be equal to 'fail'
 
@@ -206,7 +208,7 @@ Error, <val> must not be equal to 'fail'
 
 # test input validation for DS_Hash_SetValue
 gap> DS_Hash_Reserve(fail, 100);
-Error, <ht> must be a hashmap object (not a boolean or fail)
+Error, <ht> must be a hashmap or hashset (not a boolean or fail)
 gap> DS_Hash_Reserve(hashmap, fail);
 Error, <capacity> must be a small positive integer (not a boolean or fail)
 
@@ -224,23 +226,23 @@ Error, <accufunc> must be a function (not a boolean or fail)
 gap> _DS_Hash_Lookup(hashmap, fail);
 Error, <key> must not be equal to 'fail'
 gap> _DS_Hash_Lookup(fail, 3000);
-Error, <ht> must be a hashmap object (not a boolean or fail)
+Error, <ht> must be a hashmap or hashset (not a boolean or fail)
 
 # test input validation for _DS_Hash_LookupCreate
 gap> _DS_Hash_LookupCreate(hashmap, fail);
 Error, <key> must not be equal to 'fail'
 gap> _DS_Hash_LookupCreate(fail, 3000);
-Error, <ht> must be a hashmap object (not a boolean or fail)
+Error, <ht> must be a hashmap or hashset (not a boolean or fail)
 
 #
-gap> badHashmap := DS_Hash_Create( x -> "hash", \=, 5 );;
+gap> badHashmap := HashMap( x -> "hash" );;
 gap> DS_Hash_Contains(badHashmap, 1);
 Error, <hashfun> must return a small int (not a list (string))
 
 #
 # test reserving capacity
 #
-gap> hashmap := DS_Hash_Create( IdFunc, \=, 5 );
+gap> hashmap := HashMap();
 <hash map obj capacity=16 used=0>
 gap> for i in [1..1400] do DS_Hash_SetValue(hashmap, i, i^2); od;
 gap> hashmap;
@@ -304,7 +306,7 @@ true
 # Test hash map with non-standard equality,
 # namely: identity.
 #
-gap> hashmap := DS_Hash_Create( {x} -> (HANDLE_OBJ(x) mod 2^20), IsIdenticalObj, 5 );
+gap> hashmap := HashMap( {x} -> (HANDLE_OBJ(x) mod 2^20), IsIdenticalObj );
 <hash map obj capacity=16 used=0>
 gap> hashmap["foo"] := 1;;
 gap> hashmap["foo"] := 2;;

--- a/tst/hashset.tst
+++ b/tst/hashset.tst
@@ -1,0 +1,66 @@
+##########################################
+#
+# Test hash set with integer keys
+#
+
+# setup
+gap> N := 100000;;
+gap> primes := Filtered([1..N], IsPrimeInt);;
+
+# create new empty hash set
+gap> hashset := HashSet();
+<hash set obj capacity=16 used=0>
+gap> IsEmpty(hashset);
+true
+
+# add stuff
+gap> for p in primes do AddSet(hashset, p); od;
+
+# verify
+gap> ForAll([1..N], i -> (i in hashset) = (i in primes));
+true
+gap> Size(hashset) = Length(primes);
+true
+gap> IsEmpty(hashset);
+false
+
+#
+gap> 43 in hashset;
+true
+gap> 42 in hashset;
+false
+
+#
+# Test deleting entries of the hash set
+#
+
+# delete something
+gap> RemoveSet(hashset, 43);
+gap> 43 in hashset;
+false
+
+# attempt to delete something which never was in the hash set
+gap> RemoveSet(hashset, 42);
+fail
+
+# attempt to delete something already deleted
+gap> RemoveSet(hashset, 43);
+fail
+
+# set previously deleted key again
+gap> AddSet(hashset, 43);
+gap> 43 in hashset;
+true
+
+# verify
+gap> ForAll([1..N], i -> (i in hashset) = (i in primes));
+true
+gap> Size(hashset) = Length(primes);
+true
+gap> IsEmpty(hashset);
+false
+
+# verify
+gap> for p in primes do RemoveSet(hashset, p); od;
+gap> IsEmpty(hashset);
+true


### PR DESCRIPTION
This reuses code from HashMap, but does not store values associated to keys, and provides a slightly different interface, in terms of AddSet, RemoveSet and \in.

In the future, we could also add methods for things like `UniteSet`, `Union`, `Intersection` etc. *should we want to*. Perhaps also a constructor to convert an ordered (GAP) set into a hash set.
