### PR TITLE
Install ViewString instead of ViewObj

### DIFF
--- a/gap/binaryheap.gi
+++ b/gap/binaryheap.gi
@@ -91,10 +91,10 @@ InstallOtherMethod(IsEmpty,
     [IsBinaryHeapFlatRep],
     heap -> Length(heap![2]) = 0);
 
-InstallMethod(ViewObj,
+InstallMethod(ViewString,
     "for a binary heap in flat representation",
     [IsBinaryHeapFlatRep],
 function(heap)
-    Print("<binary heap with ", Length(heap![2]), " entries>");
+    return STRINGIFY("<binary heap with ", Length(heap![2]), " entries>");
 end);
 

--- a/gap/hashmap.gi
+++ b/gap/hashmap.gi
@@ -36,10 +36,10 @@ function(arg...)
     return DS_Hash_Create(hashfunc, eqfunc, capacity);
 end);
 
-InstallMethod(ViewObj, "for hash maps",
+InstallMethod(ViewString, "for hash maps",
     [ IsHashMapRep ],
 function(ht)
-    Print("<hash map obj capacity=",DS_Hash_Capacity(ht),
+    return STRINGIFY("<hash map obj capacity=",DS_Hash_Capacity(ht),
             " used=",DS_Hash_Used(ht),">");
 end);
 

--- a/gap/pairingheap.gi
+++ b/gap/pairingheap.gi
@@ -122,11 +122,11 @@ InstallOtherMethod(IsEmpty
         , [IsPairingHeapFlatRep]
         , h -> h![1] = 0);
 
-InstallMethod( ViewObj,
+InstallMethod( ViewString,
         "for a pairing heap in flat representation",
         [ IsPairingHeapFlatRep ],
 function(h)
-    Print("<pairing heap with "
-          , h![1]
-          , " entries>");
+    return STRINGIFY("<pairing heap with "
+                    , h![1]
+                    , " entries>");
 end);

--- a/gap/plistdeque.gi
+++ b/gap/plistdeque.gi
@@ -293,11 +293,11 @@ function(deque)
     return deque![QCAPACITY];
 end);
 
-InstallMethod( ViewObj,
+InstallMethod( ViewString,
         "for a PlistDeque",
         [ IsPlistDequeRep ],
 function(deque)
-    Print("<deque with ");
-    Print(Size(deque),"/",Capacity(deque));
-    Print(" entries>");
+    return STRINGIFY("<deque with "
+                    , Size(deque), "/", Capacity(deque)
+                    , " entries>");
 end);

--- a/gap/stack.gi
+++ b/gap/stack.gi
@@ -48,10 +48,10 @@ InstallOtherMethod(Size
               , [IsStack]
               , s -> Length(s![1]));
 
-InstallMethod(ViewObj
+InstallMethod(ViewString
              , "for a stack"
              , [IsStack],
 function(s)
-    Print("<stack with ", Length(s![1]), " entries>");
+    return STRINGIFY("<stack with ", Length(s![1]), " entries>");
 end);
 


### PR DESCRIPTION
This works better with the Jupyter kernel and any future implementation
of printing/viewing.

Since these ViewStrings are fairly short there is also no harm in
producing the string before printing.
