### PR TITLE
Fix input checks and mutability issues

### DIFF
--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -12,6 +12,7 @@
 #include "src/debug.h"
 #include "src/ariths.h"
 #include "src/intfuncs.h"
+#include "src/objects.h"
 
 enum {
     // offsets in the hashmap positional object
@@ -313,6 +314,13 @@ static void DS_RequireHashMap(Obj ht)
     }
 }
 
+static void DS_RequireMutable(Obj ht)
+{
+    if (!IS_MUTABLE_OBJ(ht)) {
+        ErrorQuit("<ht> must be a mutable hashmap or hashset",
+                  0, 0);
+    }
+}
 
 //
 // high-level functions, to be called from GAP
@@ -417,6 +425,7 @@ Obj DS_Hash_Value(Obj self, Obj ht, Obj key)
 Obj DS_Hash_Reserve(Obj self, Obj ht, Obj new_capacity)
 {
     DS_RequireHashMapOrSet(ht);
+    DS_RequireMutable(ht);
     if (!IS_POS_INTOBJ(new_capacity)) {
         ErrorQuit("<capacity> must be a small positive integer (not a %s)",
                   (Int)TNAM_OBJ(new_capacity), 0);
@@ -444,12 +453,14 @@ Obj DS_Hash_Reserve(Obj self, Obj ht, Obj new_capacity)
 Obj DS_Hash_SetValue(Obj self, Obj ht, Obj key, Obj val)
 {
     DS_RequireHashMap(ht);
+    DS_RequireMutable(ht);
     return _DS_Hash_SetOrAccValue(ht, key, val, 0);
 }
 
 Obj DS_Hash_AccumulateValue(Obj self, Obj ht, Obj key, Obj val, Obj accufunc)
 {
     DS_RequireHashMap(ht);
+    DS_RequireMutable(ht);
     if (TNUM_OBJ(accufunc) != T_FUNCTION) {
         ErrorQuit("<accufunc> must be a function (not a %s)",
                   (Int)TNAM_OBJ(accufunc), 0);
@@ -460,6 +471,7 @@ Obj DS_Hash_AccumulateValue(Obj self, Obj ht, Obj key, Obj val, Obj accufunc)
 Obj DS_Hash_AddSet(Obj self, Obj ht, Obj key)
 {
     DS_RequireHashSet(ht);
+    DS_RequireMutable(ht);
     _DS_Hash_AddSet(ht, key);
     return 0;
 }
@@ -467,6 +479,7 @@ Obj DS_Hash_AddSet(Obj self, Obj ht, Obj key)
 Obj DS_Hash_Delete(Obj self, Obj ht, Obj key)
 {
     DS_RequireHashMapOrSet(ht);
+    DS_RequireMutable(ht);
     UInt idx = _DS_Hash_Lookup_MayCreate(ht, key, 0);
     if (!idx)
         return Fail;

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -1,4 +1,3 @@
-//
 // Datastructures: GAP package providing common datastructures.
 //
 // Copyright (C) 2015-2017  The datastructures team.
@@ -33,7 +32,9 @@ enum {
 };
 
 static Obj HashMapType;    // Imported from the library
+static Obj IsHashMapRep;    // Imported from the library
 static Obj HashSetType;    // Imported from the library
+static Obj IsHashSetRep;    // Imported from the library
 
 static inline Int IsHashSet(Obj ht)
 {
@@ -289,8 +290,9 @@ static void _DS_Hash_AddSet(Obj ht, Obj key)
 
 static void DS_RequireHashMapOrSet(Obj ht)
 {
-    if (TNUM_OBJ(ht) != T_POSOBJ || (TYPE_POSOBJ(ht) != HashMapType
-        && TYPE_POSOBJ(ht) != HashSetType)) {
+    if (TNUM_OBJ(ht) != T_POSOBJ ||
+        (DoFilter(IsHashSetRep, ht) == False &&
+         DoFilter(IsHashMapRep, ht) == False)) {
         ErrorQuit("<ht> must be a hashmap or hashset (not a %s)",
                   (Int)TNAM_OBJ(ht), 0);
     }
@@ -298,15 +300,14 @@ static void DS_RequireHashMapOrSet(Obj ht)
 
 static void DS_RequireHashSet(Obj ht)
 {
-    if (TNUM_OBJ(ht) != T_POSOBJ || TYPE_POSOBJ(ht) != HashSetType) {
-        ErrorQuit("<ht> must be a hashset (not a %s)",
-                  (Int)TNAM_OBJ(ht), 0);
+    if (TNUM_OBJ(ht) != T_POSOBJ || DoFilter(IsHashSetRep, ht) == False) {
+        ErrorQuit("<ht> must be a hashset (not a %s)", (Int)TNAM_OBJ(ht), 0);
     }
 }
 
 static void DS_RequireHashMap(Obj ht)
 {
-    if (TNUM_OBJ(ht) != T_POSOBJ || TYPE_POSOBJ(ht) != HashMapType) {
+    if (TNUM_OBJ(ht) != T_POSOBJ || DoFilter(IsHashMapRep, ht) == False) {
         ErrorQuit("<ht> must be a hashmap object (not a %s)",
                   (Int)TNAM_OBJ(ht), 0);
     }
@@ -513,7 +514,9 @@ static Int InitKernel(void)
     InitHdlrFuncsFromTable(GVarFuncs);
 
     ImportGVarFromLibrary("HashMapType", &HashMapType);
+    ImportGVarFromLibrary("IsHashMapRep", &IsHashMapRep);
     ImportGVarFromLibrary("HashSetType", &HashSetType);
+    ImportGVarFromLibrary("IsHashSetRep", &IsHashSetRep);
 
     return 0;
 }

--- a/tst/hashmap.tst
+++ b/tst/hashmap.tst
@@ -386,5 +386,26 @@ true
 gap> hashmap[foo];
 3
 
+##########################################
+#
+# Test mutability
+#
+gap> hashmap := HashMap();
+<hash map obj capacity=16 used=0>
+gap> hashmap[15] := "";
+""
+gap> MakeImmutable(hashmap);
+<hash map obj capacity=16 used=1>
+gap> IsMutable(hashmap);
+false
+gap> hashmap[15] := "2";
+Error, <ht> must be a mutable hashmap or hashset
+gap> hashmap[17] := 7;
+Error, <ht> must be a mutable hashmap or hashset
+gap> Unbind(hashmap[17]);
+Error, <ht> must be a mutable hashmap or hashset
+gap> DS_Hash_AccumulateValue(hashmap, 567, 1, SUM);
+Error, <ht> must be a mutable hashmap or hashset
+
 #
 gap> STOP_TEST( "hashmap.tst", 1);

--- a/tst/hashset.tst
+++ b/tst/hashset.tst
@@ -109,3 +109,16 @@ gap> List(Iterator(hashset));
 gap> hashset := HashSet();;
 gap> it := Iterator(hashset);; NextIterator(it);
 Error, <iter> is exhausted
+
+# mutability
+gap> hashset := HashSet();
+<hash set obj capacity=16 used=0>
+gap> AddSet(hashset, 15);
+gap> MakeImmutable(hashset);
+<hash set obj capacity=16 used=1>
+gap> AddSet(hashset, 15);
+Error, <ht> must be a mutable hashmap or hashset
+gap> RemoveSet(hashset, 20);
+Error, <ht> must be a mutable hashmap or hashset
+
+


### PR DESCRIPTION
The requirement checks for inputs to hashset and hashmap functions used to test the type of the input object, which is incorrect, they should be testing the representation of the input object.

This lead to problems when the user or GAP made HashMaps or HashSets immutable, because that changes their type, and no functions for them work anymore.