### PR TITLE
Make Immutable copy of keys in Hashed containers

### DIFF
--- a/gap/hashmap.gi
+++ b/gap/hashmap.gi
@@ -55,8 +55,8 @@ InstallOtherMethod(\[\],
     DS_Hash_Value); # TODO: raise an error if key is not bound
 
 #! @Description
-#! List-style access for hashmaps.
-#! @Arguments hashmap, object
+#! List-style assignment for hashmaps.
+#! @Arguments hashmap, object, object
 InstallOtherMethod(\[\]\:\=,
     "for a hash map, a key and a value",
     [ IsHashMapRep, IsObject, IsObject ],

--- a/gap/union-find.gd
+++ b/gap/union-find.gd
@@ -31,7 +31,7 @@ DeclareCategory("IsPartitionDS", IsObject);
 BindGlobal("PartitionDSFamily", NewFamily(IsPartitionDS));
 
 #
-# Constructors. Given an integer return the trivial partittion (n parts of size 1)
+# Constructors. Given an integer return the trivial partition (n parts of size 1)
 # Given a list of disjoint sets, return that partition. Any points up to the maximum
 # of any of the sets not included in a set are in singleton parts.
 #

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -255,7 +255,7 @@ static Obj _DS_Hash_SetOrAccValue(Obj ht, Obj key, Obj val, Obj accufunc)
     }
     else {
         DS_IncrementCounterInPlist(ht, POS_USED, INTOBJ_INT(1));
-
+        key = CopyObj(key, 0);
         SET_ELM_PLIST(keys, idx, key);
         SET_ELM_PLIST(values, idx, val);
         CHANGED_BAG(keys);
@@ -283,6 +283,7 @@ static void _DS_Hash_AddSet(Obj ht, Obj key)
     }
 
     if (old_k == Fail || old_k == 0) {
+        key = CopyObj(key, 0);
         DS_IncrementCounterInPlist(ht, POS_USED, INTOBJ_INT(1));
         SET_ELM_PLIST(keys, idx, key);
         CHANGED_BAG(keys);

--- a/tst/hashmap.tst
+++ b/tst/hashmap.tst
@@ -375,7 +375,8 @@ gap> hashmap["foo"];
 fail
 
 # now insert a key to which we keep a reference
-gap> foo:="foo";;
+# must be immutable else an immutable copy will be made on insertion
+gap> foo:=Immutable("foo");;
 gap> hashmap[foo] := 3;;
 gap> DS_Hash_Contains(hashmap, foo);
 true
@@ -406,6 +407,17 @@ gap> Unbind(hashmap[17]);
 Error, <ht> must be a mutable hashmap or hashset
 gap> DS_Hash_AccumulateValue(hashmap, 567, 1, SUM);
 Error, <ht> must be a mutable hashmap or hashset
+
+# Test key mutability
+gap> l := [1];;
+gap> hashmap := HashMap();;
+gap> hashmap[l] := 2;;
+gap> Add(l, 2);;
+gap> hashmap[l] := 3;;
+gap> hashmap[l];
+3
+gap> hashmap[[1]];
+2
 
 #
 gap> STOP_TEST( "hashmap.tst", 1);


### PR DESCRIPTION
This isn't really documented, because I wasn't really sure where to document it, and we didn't document the old behaviour before anyway.

Also contains two tiny comment fixes.