### PR TITLE
Change to a stable hash function for records

### DIFF
--- a/src/hashfunctions.c
+++ b/src/hashfunctions.c
@@ -176,17 +176,22 @@ Int BasicRecursiveHashForPRec(Obj obj)
 {
     GAP_ASSERT(IS_PREC(obj));
 
-    // This is just a random number which fits in a 32-bit UInt.
+    // This is just a random number which fits in a 32-bit UInt,
+    // mainly to give the hash value of an empty record a value which
+    // is unlikely to clash with anything else
     UInt current_hash = 1928498392;
-
-    /* ensure record is sorted */
-    SortPRecRNam(obj, 0);
 
     /* hash componentwise                                               */
     for (Int i = 1; i <= LEN_PREC(obj); i++) {
-        UInt recname = GET_RNAM_PREC(obj, i);
+        // labs, as this can be negative in an unsorted record
+        UInt recname = labs(GET_RNAM_PREC(obj, i));
+        Obj  recnameobj = NAME_RNAM(recname);
+        // The '23792' here is just a seed value.
+        Int  hashrecname = HASHKEY_WHOLE_BAG_NC(recnameobj, 23792);
         UInt rechash = BasicRecursiveHash(GET_ELM_PREC(obj, i));
-        current_hash = HashCombine3(current_hash, recname, rechash);
+
+        // Use +, because record may be out of order
+        current_hash += HashCombine2(hashrecname, rechash);
     }
 
     return current_hash;

--- a/tst/hashfunctions/recursive.tst
+++ b/tst/hashfunctions/recursive.tst
@@ -39,5 +39,19 @@ gap> HashBasic(1,2,3,4,5) = HashBasic([1,2,3,4,5]);
 true
 gap> HashBasic(1,2,3,4,5,6,7,8,9,10) = HashBasic([1,2,3,4,5,6,7,8,9,10]);
 true
+
+# Make two records, one internally sorted, one not.
+gap> rec1 := rec(aaax := 1, aaay := 2, aaaz := 3);;
+gap> rec2 := rec(aaay := 2, aaaz := 3, aaax := 1);;
+gap> rec1;
+rec( aaax := 1, aaay := 2, aaaz := 3 )
+gap> HashBasic(rec1) = HashBasic(rec2);
+true
+gap> rec1.aaaq := 9;; rec1.aaap := 8;;
+gap> rec2.aaap := 8;; rec2.aaaq := 9;;
+gap> HashBasic(rec1) = HashBasic(rec2);
+true
+
+# Check objects we don't handle
 gap> HashBasic(SymmetricGroup(3));
 Error, Unable to hash object (component)


### PR DESCRIPTION
The old hash function required calling SortPRecRNam, and also
would be effected by how GAP mapped record keys to RNams, meaning
different GAP sessions could return different answers.

Switch to actually hashing the keys, and also using '+' to combine
the different key-value pairs, so the hash value is unaffected by
how GAP stores records.

I have tested manually that if I load GAP and define keys in different orders I get the same hash output, but I can't think how to sensibly add this to a test file.