### PR TITLE
Add ViewObj for slices, fix ViewString rank

### DIFF
--- a/gap/slice.gi
+++ b/gap/slice.gi
@@ -36,9 +36,15 @@ function(list, begin, len)
 end);
 
 InstallMethod(ViewString, "for slices",
-    [ IsSliceRep ],
+    [ IsSliceRep ], SUM_FLAGS,
 function(slice)
     return STRINGIFY("<slice size=", slice!.len, ">");
+end);
+
+InstallMethod(ViewObj, "for slices",
+    [ IsSliceRep ], SUM_FLAGS,
+function(slice)
+    Print("<slice size=", slice!.len, ">");
 end);
 
 #! @Description

--- a/tst/slice.tst
+++ b/tst/slice.tst
@@ -3,7 +3,7 @@ gap> LoadPackage("datastructures", false);
 true
 gap> x := [1,5,3,2,4,6,4,3];;
 gap> s := Slice(x, 3, 3);
-[ 3, 2, 4 ]
+<slice size=3>
 gap> List(s);
 [ 3, 2, 4 ]
 gap> Length(s);
@@ -47,7 +47,7 @@ gap> List(s);
 gap> List(x);
 [ 1, 5, 9,, 4, 6, 4, 3 ]
 gap> s := Slice(x, 3, 0);
-[  ]
+<slice size=0>
 gap> Length(s);
 0
 gap> List(s);
@@ -55,7 +55,7 @@ gap> List(s);
 gap> s[1];
 Error, Cannot access element 1 of a range with 0 elements
 gap> s := Slice(x, 1, 1);
-[ 1 ]
+<slice size=1>
 gap> s[0];
 Error, no method found! For debugging hints type ?Recovery from NoMethodFound
 Error, no 1st choice method found for `[]' on 2 arguments
@@ -65,7 +65,7 @@ gap> s[2];
 Error, Cannot access element 2 of a range with 1 elements
 gap> x:= [1,5,3,2,4,,4,3];;
 gap> s:= Slice( x, 2, 6 );
-[ 5, 3, 2, 4,, 4 ]
+<slice size=6>
 gap> Slice( s, 2, 4 );
-[ 3, 2, 4, ]
+<slice size=4>
 gap> STOP_TEST( "slice.tst" );


### PR DESCRIPTION
If all packages were loaded, the generic GAP library method for ViewString
was ranked higher than our custom method, which is now fixed. This fixes test failures as seen e.g. [here](https://travis-ci.org/gap-infra/gap-docker-pkg-tests-master-staging/jobs/579543541).

Also add a ViewObj method matching the ViewString method.