### PR TITLE
Show AppVeyor build status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/gap-packages/datastructures.svg?branch=master)](https://travis-ci.org/gap-packages/datastructures)
+[![Travis Build Status](https://travis-ci.org/gap-packages/datastructures.svg?branch=master)](https://travis-ci.org/gap-packages/datastructures)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/gap-packages/datastructures?branch=master&svg=true)](https://ci.appveyor.com/project/gap-packages/datastructures)
 [![Code Coverage](https://codecov.io/github/gap-packages/datastructures/coverage.svg?branch=master&token=)](https://codecov.io/gh/gap-packages/datastructures)
 
 # The datastructures GAP package


### PR DESCRIPTION
However, first we should make sure that AppVeyor builds actually work... When I just checked, they were not actually enabled - huh? I fixed that now, and started a build, let's see if it passes.