### PR TITLE
Fix positional object reference.

### DIFF
--- a/gap/ordered.gd
+++ b/gap/ordered.gd
@@ -85,7 +85,7 @@
 DeclareCategory("IsOrderedSetDS", IsObject);
 
 #! @Description
-#! Subcategory of ordered sets where the ordering is &GAP;'s default $\leq$
+#! Subcategory of ordered sets where the ordering is &GAP;'s default <C>&lt;</C>
 DeclareCategory("IsStandardOrderedSetDS", IsOrderedSetDS);
 
 #! @Description
@@ -99,7 +99,7 @@ BindGlobal( "OrderedSetDSFamily", NewFamily("OrderedSetDSFamily") );
 #! object will have.<P/>
 #! The optional argument <A>lessThan</A> must be a binary function that returns <K>true</K> if
 #! its first argument is less than its second argument, and <K>false</K> otherwise. The default
-#! <A>lessThan</A> is &GAP;'s built in $\leq$.<P/>
+#! <A>lessThan</A> is &GAP;'s built in <C>&lt;</C>.<P/>
 #! The optional argument <A> initialEntries</A> gives a collection of elements that the ordered
 #! set is initialised with, and defaults to the empty set.<P/>
 #! The optional argument <A>randomSource</A > is

--- a/gap/ordered.gd
+++ b/gap/ordered.gd
@@ -85,7 +85,7 @@
 DeclareCategory("IsOrderedSetDS", IsObject);
 
 #! @Description
-#! Subcategory of ordered sets where the ordering is &GAP;'s default &leq;
+#! Subcategory of ordered sets where the ordering is &GAP;'s default $\leq$
 DeclareCategory("IsStandardOrderedSetDS", IsOrderedSetDS);
 
 #! @Description
@@ -99,7 +99,7 @@ BindGlobal( "OrderedSetDSFamily", NewFamily("OrderedSetDSFamily") );
 #! object will have.<P/>
 #! The optional argument <A>lessThan</A> must be a binary function that returns <K>true</K> if
 #! its first argument is less than its second argument, and <K>false</K> otherwise. The default
-#! <A>lessThan</A> is &GAP;'s built in &leq;.<P/>
+#! <A>lessThan</A> is &GAP;'s built in $\leq$.<P/>
 #! The optional argument <A> initialEntries</A> gives a collection of elements that the ordered
 #! set is initialised with, and defaults to the empty set.<P/>
 #! The optional argument <A>randomSource</A > is

--- a/gap/plistdeque.gd
+++ b/gap/plistdeque.gd
@@ -13,7 +13,7 @@
 #!
 #! <Package>datastructures</Package> implements deques
 #! using a circular buffer stored in a &GAP; a plain list,
-#! wrapped in a positional object (<Ref Filt="IsPositionalObjectRep" BookName="Ref"/>).
+#! wrapped in a positional object (<Ref Sect="Positional Objects" BookName="ref"/>).
 #!
 #! The five positions in such a deque <C>Q</C> have the following purpose
 #!


### PR DESCRIPTION
Gap 4.10.2, at least, does not seem to have a label for IsPositionalObjectRep:
```
#W WARNING: non resolved reference: rec(
  BookName := "Ref",
  Filt := "IsPositionalObjectRep" )
```
Given the referring text, a reference to the enclosing section seems more appropriate anyway.