### PR TITLE
Improve buildsystem, use shared Makefile.gappkg

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,8 +2,6 @@
 clone_depth: 5                  # clone entire repository history if not defined
 
 environment:
-  GAPROOT: "gaproot"
-  COVDIR: "coverage"
   matrix:
     - CYG_ARCH: x86
       CYG_ROOT: C:\cygwin

--- a/.gitignore
+++ b/.gitignore
@@ -24,11 +24,8 @@
 /doc/_*.xml
 
 /bin/
-/obj/
+/gen/
 /Makefile
 
-*.la
-src/*.lo
-
-/build/
+/tmp/
 /gh-pages/

--- a/Makefile.gappkg
+++ b/Makefile.gappkg
@@ -1,0 +1,146 @@
+########################################################################
+#
+# The build rules in this file are intended for use by GAP packages that
+# want to build a simple GAP kernel extensions. They are based on the
+# GAP build system, and require GNU make. To use this in your GAP
+# package, `include` this from your primary Makefile. You must also set
+# several variables beforehand:
+#
+# - GAPPATH must be set to the location of the GAP installation against
+#   which to build your package.
+# - KEXT_NAME should be the name of your kernel extension (without
+#   file extensions like .so or .dll)
+# - KEXT_SOURCES must contain a list of .c or .cc files to be linked
+#   into your kernel extension
+# - optionally, you can set KEXT_CFLAGS, KEXT_CXXFLAGS, KEXT_LDFLAGS
+#
+#
+# Only GAP >= 4.11 ships with this file. In order to keep your package
+# compatible with older GAP versions, we recommend to bundle a copy of
+# it with your package, but only as a fallback. So, your configure
+# scripts should check if GAP ships with this file, and use it then, and
+# only fall back to your own copy as a last resort. This way, you will
+# benefit from any fixes and improvements made by the GAP team.
+#
+# The contents of this file are released into the public domain; hence
+# you may edit this file as you wish, bundle and distribute it with your
+# package, etc.
+#
+# If you bundle this file with your package, please try not to edit it,
+# so that we can keep it identical across all GAP packages. If you still
+# find that you must edit it, please consider submitting your changes
+# back to the GAP team, so that a future version of this file can be
+# adjusted to cover your usecase without modifications.
+#
+########################################################################
+
+# read GAP's build settings
+include $(GAPPATH)/sysinfo.gap
+
+# various derived settings
+KEXT_BINARCHDIR = bin/$(GAParch)
+KEXT_SO = $(KEXT_BINARCHDIR)/$(KEXT_NAME).so
+
+GAP = $(GAPPATH)/gap
+GAC = $(GAPPATH)/gac
+
+# override KEXT_RECONF if your package needs a different invocation
+# for reconfiguring (e.g. `./config.status --recheck` for autoconf)
+KEXT_RECONF ?= ./configure "$(GAPPATH)"
+
+# default target
+all: $(KEXT_SO)
+.PHONY: all
+
+########################################################################
+# Object files
+# For each file FOO.c in SOURCES, add gen/FOO.lo to KEXT_OBJS; similar
+# for .cc files
+########################################################################
+KEXT_OBJS = $(patsubst %.cc,gen/%.lo,$(patsubst %.c,gen/%.lo,$(KEXT_SOURCES)))
+
+########################################################################
+# Quiet rules.
+#
+# Replace regular output with quiet messages, unless V is set,
+# e.g. "make V=1"
+########################################################################
+ifneq ($(findstring $(MAKEFLAGS),s),s)
+ifndef V
+QUIET_GAC     = @echo "   GAC     $< => $@";
+endif
+endif
+
+########################################################################
+# Rules for automatic header dependency tracking.
+# This is based on the GAP build system.
+########################################################################
+
+# List of all (potential) dependency directories, derived from KEXT_OBJS
+# and KEXT_SOURCES (the latter for generated sources, which may also
+# involve dependency tracking)
+KEXT_DEPDIRS = $(sort $(dir $(KEXT_SOURCES) $(KEXT_OBJS)))
+KEXT_DEPFILES = $(wildcard $(addsuffix /*.d,$(KEXT_DEPDIRS)))
+
+# Include the dependency tracking files.
+-include $(KEXT_DEPFILES)
+
+# Mark *.d files as PHONY. This stops make from trying to recreate them
+# (which it can't), and in particular from looking for potential source
+# files. This can save quite a bit of disk access time.
+.PHONY: $(KEXT_DEPFILES)
+
+# The following flags instruct the compiler to enable advanced
+# dependency tracking. Supported by GCC 3 and newer; clang; Intel C
+# compiler; and more.
+KEXT_DEPFLAGS = -MQ "$@" -MMD -MP -MF $(@D)/$(*F).d
+
+# build rule for C code
+# The dependency on Makefile ensures that re-running configure recompiles everything
+gen/%.lo: %.c Makefile
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CFLAGS)" -c $< -o $@
+
+# build rule for C++ code
+# The dependency on Makefile ensures that re-running configure recompiles everything
+gen/%.lo: %.cc Makefile
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -p "$(KEXT_CXXFLAGS)" -c $< -o $@
+
+# build rule for linking all object files together into a kernel extension
+$(KEXT_SO): $(KEXT_OBJS)
+	@mkdir -p $(KEXT_BINARCHDIR)
+	$(QUIET_GAC)$(GAC) -d -p "$(KEXT_DEPFLAGS)" -P "$(KEXT_LDFLAGS)" $(KEXT_OBJS) -o $@
+
+# hook into `make clean`
+clean: clean-kext
+clean-kext:
+	rm -rf $(KEXT_BINARCHDIR) gen
+
+# hook into `make distclean`
+distclean: clean-kext
+distclean-kext:
+	rm -rf bin gen Makefile
+	(cd doc && ./clean)
+
+# hook into `make doc`
+doc: doc-kext
+doc-kext:
+	$(GAP) makedoc.g
+
+# hook into `make check`
+check: check-kext
+check-kext:
+	$(GAP) tst/testall.g
+
+# re-run configure if configure, Makefile.in or GAP itself changed
+Makefile: configure Makefile.in $(GAPPATH)/sysinfo.gap
+	$(KEXT_RECONF)
+
+.PHONY: check clean distclean doc
+.PHONY: check-kext clean-kext distclean-kext doc-kext
+
+########################################################################
+# Makefile debugging trick:
+# call print-VARIABLE to see the runtime value of any variable
+########################################################################
+print-%:
+	@echo '$*=$($*)'

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,135 +1,18 @@
 #
 # Makefile rules for the datastructures package
 #
-# This requires GNU make (just as the main GAP does).
-#
-# For simple packages one should only need to modify the MODULE_NAME
-# and the SOURCES variable.
-#
-MODULE_NAME = datastructures
+KEXT_NAME = datastructures
 
-SOURCES =
-SOURCES += src/avl.c
-SOURCES += src/binaryheap.c
-SOURCES += src/datastructures.c
-SOURCES += src/hashfunctions.c
-SOURCES += src/hashmap.c
-SOURCES += src/pairingheap.c
-SOURCES += src/skiplist.c
-SOURCES += src/uf.c
+KEXT_SOURCES =
+KEXT_SOURCES += src/avl.c
+KEXT_SOURCES += src/binaryheap.c
+KEXT_SOURCES += src/datastructures.c
+KEXT_SOURCES += src/hashfunctions.c
+KEXT_SOURCES += src/hashmap.c
+KEXT_SOURCES += src/pairingheap.c
+KEXT_SOURCES += src/skiplist.c
+KEXT_SOURCES += src/uf.c
 
-########################################################################
-# Do not edit below (unless you know what you're doing.
-########################################################################
-
-########################################################################
-# Some variables (that should come from GAP's configure'd setup
-########################################################################
+# include shared GAP package build system
 GAPPATH = @GAPPATH@
-GAPARCH = @GAPARCH@
-
-BINARCHDIR = bin/@GAPARCH@
-GAPINSTALLIB = $(BINARCHDIR)/$(MODULE_NAME).so
-
-MKDIR_P = /bin/mkdir -p
-
-GAP = @GAPPATH@/gap
-GAC = @GAPPATH@/gac
-
-all: $(GAPINSTALLIB)
-.PHONY: all
-
-########################################################################
-# Object files
-########################################################################
-
-# OBJS shall contain the names of all object files that constitute the
-# package's kernel library.
-OBJS = $(patsubst src/%.c,obj/%.lo,$(SOURCES))
-
-########################################################################
-# Quiet rules.
-#
-# Replace regular output with quiet messages, unless V is set,
-# e.g. "make V=1"
-########################################################################
-ifneq ($(findstring $(MAKEFLAGS),s),s)
-ifndef V
-QUIET_GAC     = @echo "   GAC     $< => $@";
-LIBTOOL          += --silent
-endif
-endif
-
-########################################################################
-# Rules for automatic header dependency tracking.
-#
-# This is somewhat similar to what automake does, but relies on compiler
-# support. The result is much simpler.
-#
-# So, here is what happens: In each directory containing source files,
-# a ".deps" subdirectory is created. We then instruct the compiler via
-# some flags to create a ".deps/FOO.d" file when it compiles "FOO.c".
-# This file encodes the header dependencies of "FOO.c" in a way that
-# make can read (i.e. simply as a bunch of make targets with
-# dependencies).
-#
-# Finally, to let make track the header dependencies, we include the *.d files.
-#
-# For a more detailed explanation of a very similar scheme, read this:
-# http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/
-#
-########################################################################
-
-# Name of subdirectories in which the generated dependencies are stored.
-DEPDIRNAME := .deps
-
-# List of all (potential) dependency directories, derived from OBJS
-# and SOURCES (the latter for generated sources, which may also involve
-# dependency tracking)
-DEPDIRS = $(addsuffix $(DEPDIRNAME),$(sort $(dir $(SOURCES) $(OBJS))))
-
-# Include the dependency tracking files.
--include $(wildcard $(addsuffix /*.d,$(DEPDIRS)))
-
-# Mark *.d files as PHONY. This stops make from trying to
-# recreate them (which it can't), and in particular from looking for potential
-# source files. This can save quite a bit of disk access time.
-.PHONY: $(wildcard $(addsuffix /*.d,$(DEPDIRS)))
-
-DEPFILE = "$(@D)/$(DEPDIRNAME)/$(*F).d"
-
-# The following flags instruct the compiler to enable advanced
-# dependency tracking. Supported by GCC 3 and newer; clang; Intel C
-# compiler; and more.
-#
-# TODO: use configure to compute DEPFLAGS, so that we can
-# disable it for compilers that don't support it, resp. replace it
-# something that works for that compiler
-DEPFLAGS = -MQ "$@" -MMD -MP -MF $(DEPFILE)
-
-obj/%.lo: src/%.c
-	@$(MKDIR_P) $(@D)/$(DEPDIRNAME)
-	@$(QUIET_GAC)$(GAC) -d -p "$(DEPFLAGS)" -c $< -o $@
-
-$(GAPINSTALLIB): $(OBJS)
-	@$(MKDIR_P) $(BINARCHDIR)
-	@$(QUIET_GAC)$(GAC) -d -p "$(DEPFLAGS)" $(OBJS) -o $@
-
-clean:
-	rm -rf $(BINARCHDIR)
-	rm -rf obj
-
-distclean:
-	rm -rf bin obj Makefile
-	(cd doc && ./clean)
-
-doc: default
-	$(GAP) makedoc.g
-
-check: default
-	$(GAP) tst/testall.g
-
-Makefile: configure Makefile.in
-	./configure "@GAPPATH@"
-
-.PHONY: default clean distclean doc check
+include Makefile.gappkg

--- a/configure
+++ b/configure
@@ -1,13 +1,16 @@
 #!/bin/sh
 # usage: configure gappath
 # this script creates a `Makefile' from `Makefile.in'
+
+set -e
+
 if test -z "$1"; then
   GAPPATH=../..; echo "Using ../.. as default GAP path";
 else
   GAPPATH=$1;
 fi
 
-if test ! -r $GAPPATH/sysinfo.gap ; then
+if test ! -r "$GAPPATH/sysinfo.gap" ; then
     echo
     echo "No file $GAPPATH/sysinfo.gap found."
     echo
@@ -18,15 +21,15 @@ if test ! -r $GAPPATH/sysinfo.gap ; then
     echo "Either your GAPPATH is incorrect or the GAP it is pointing to"
     echo "is not properly compiled (do \"./configure && make\" there first)."
     echo
-    echo Aborting... No Makefile is generated.
+    echo "Aborting... No Makefile is generated."
     echo
     exit 1
 fi
 
-echo "Using config in $GAPPATH/sysinfo.gap"
+echo "Using settings from $GAPPATH/sysinfo.gap"
 
-. "$GAPPATH/sysinfo.gap"
-sed \
-    -e "s;@GAPARCH@;$GAParch;g" \
-    -e "s;@GAPPATH@;$GAPPATH;g" \
-    Makefile.in > Makefile
+# update Makefile.gappkg from GAP installation, if possible
+test -r "$GAPPATH/etc/Makefile.gappkg" && cp "$GAPPATH/etc/Makefile.gappkg" .
+
+#
+sed -e "s;@GAPPATH@;$GAPPATH;g" Makefile.in > Makefile


### PR DESCRIPTION
This updates the buildsystem and factors out code shared with other packages into a new file `Makefile.gappkg`, in the hope that this will make it easier to share bugfixes and improvements between packages. (And perhaps in the future we can bundle this file with GAP itself?)