### PR TITLE
Move InitHandlerFunc uses to InitKernel

### DIFF
--- a/src/hashfunctions.c
+++ b/src/hashfunctions.c
@@ -303,6 +303,10 @@ static StructGVarFunc GVarFuncs[] = {
 static Int InitKernel(void)
 {
     InitHdlrFuncsFromTable(GVarFuncs);
+    InitHandlerFunc( DATA_HASH_FUNC_RECURSIVE1, __FILE__ ":DATA_HASH_FUNC_RECURSIVE1" );
+    InitHandlerFunc( DATA_HASH_FUNC_RECURSIVE2, __FILE__ ":DATA_HASH_FUNC_RECURSIVE2" );
+    InitHandlerFunc( DATA_HASH_FUNC_RECURSIVE3, __FILE__ ":DATA_HASH_FUNC_RECURSIVE3" );
+    InitHandlerFunc( DATA_HASH_FUNC_RECURSIVE4, __FILE__ ":DATA_HASH_FUNC_RECURSIVE4" );
     return 0;
 }
 
@@ -315,10 +319,6 @@ static Int InitLibrary(void)
     // be wrapped in a list by GAP
     Obj gvar = NewFunctionC("DATA_HASH_FUNC_RECURSIVE", -1, "arg",
                             DATA_HASH_FUNC_RECURSIVE1);
-    InitHandlerFunc( DATA_HASH_FUNC_RECURSIVE1, __FILE__ ":DATA_HASH_FUNC_RECURSIVE1" );
-    InitHandlerFunc( DATA_HASH_FUNC_RECURSIVE2, __FILE__ ":DATA_HASH_FUNC_RECURSIVE2" );
-    InitHandlerFunc( DATA_HASH_FUNC_RECURSIVE3, __FILE__ ":DATA_HASH_FUNC_RECURSIVE3" );
-    InitHandlerFunc( DATA_HASH_FUNC_RECURSIVE4, __FILE__ ":DATA_HASH_FUNC_RECURSIVE4" );
     SET_HDLR_FUNC(gvar, 1, DATA_HASH_FUNC_RECURSIVE1);
     SET_HDLR_FUNC(gvar, 2, DATA_HASH_FUNC_RECURSIVE2);
     SET_HDLR_FUNC(gvar, 3, DATA_HASH_FUNC_RECURSIVE3);


### PR DESCRIPTION
This fixes loading workspaces which use datastructures.