### PR TITLE
Adjust tests so they run on 4.10 and 4.11

### DIFF
--- a/tst/hashfunctions/recursive.tst
+++ b/tst/hashfunctions/recursive.tst
@@ -53,5 +53,10 @@ gap> HashBasic(rec1) = HashBasic(rec2);
 true
 
 # Check objects we don't handle
+#@if GAPInfo.KernelInfo.KERNEL_API_VERSION >= 7000
+gap> HashBasic(SymmetricGroup(3));
+Error, Unable to hash component object
+#@else
 gap> HashBasic(SymmetricGroup(3));
 Error, Unable to hash object (component)
+#@fi

--- a/tst/hashmap.tst
+++ b/tst/hashmap.tst
@@ -235,8 +235,13 @@ Error, <key> must not be equal to 'fail'
 # a positional object which isn't a hash map
 gap> IsPositionalObjectRep(infinity);
 true
+#@if GAPInfo.KernelInfo.KERNEL_API_VERSION >= 7000
+gap> DS_Hash_Value(infinity, 1);
+Error, <ht> must be a hashmap object (not a positional object)
+#@else
 gap> DS_Hash_Value(infinity, 1);
 Error, <ht> must be a hashmap object (not a object (positional))
+#@fi
 
 # test input validation for DS_Hash_Contains
 gap> DS_Hash_Contains(fail, 1);


### PR DESCRIPTION
Fixes #123 

Change the type we use for testing to function, as we don't really care what it is (as long as it is something we don't handle) and function's printing hasn't changed.