### PR TITLE
Add #include of stdlib.h in hashfunctions.c to get declaration of labs.

### DIFF
--- a/src/hashfunctions.c
+++ b/src/hashfunctions.c
@@ -18,6 +18,8 @@
 #include "src/trans.h"
 #include "src/pperm.h"
 
+#include <stdlib.h> // for labs
+
 
 // SquashToPerm2 takes a permutation in PERM4 form, and the largest moved
 // point of the permutation (which should be <= 65536), and returns the


### PR DESCRIPTION
My compiler (OS X Catalina) needs this include