### PR TITLE
Add printing and initial value to HashMap and HashSet

### DIFF
--- a/gap/hashmap.gd
+++ b/gap/hashmap.gd
@@ -27,15 +27,16 @@ DeclareRepresentation( "IsHashMapRep", IsHashMap and IsPositionalObjectRep, [] )
 BindGlobal( "HashMapType", NewType(HashMapFamily, IsHashMapRep and IsMutable) );
 
 #! @Description
-#! Create a new hash map. The optional argument <A>hashfunc</A> must be a hash-
-#! function , <A>eqfunc</A> must
+#! Create a new hash map. The optional argument <A>values</A> must be a list of
+#! key-value pairs which will be inserted into the new hashmap in order.
+#! The optional argument <A>hashfunc</A> must be a hash-function, <A>eqfunc</A> must
 #! be a binary equality testing function that returns <K>true</K> if the two arguments
 #! are considered equal, and <K>false</K> if they are not. Refer to Chapter
 #! <Ref Chap="Chapter_HashFunctions"/> about the requirements for hashfunctions and
 #! equality testers.
 #! The optional argument <A>capacity</A> determines the initial size of the hashmap.
 #!
-#! @Arguments [hashfunc[, eqfunc]] [capacity]
+#! @Arguments [values] [hashfunc[, eqfunc]] [capacity]
 DeclareGlobalFunction("HashMap");
 
 #! @Description

--- a/gap/hashmap.gi
+++ b/gap/hashmap.gi
@@ -54,11 +54,42 @@ function(arg...)
     return map;
 end);
 
-InstallMethod(ViewString, "for hash maps",
+InstallMethod(PrintString, "for hashmaps",
     [ IsHashMapRep ],
 function(ht)
-    return STRINGIFY("<hash map obj capacity=",DS_Hash_Capacity(ht),
-            " used=",DS_Hash_Used(ht),">");
+    local v, first, string;
+    string := [];
+    Add(string, "HashMap([\>\>");
+    first := true;
+    for v in KeyValueIterator(ht) do
+        if first then
+            first := false;
+        else
+            Add(string, ",\< \>");
+        fi;
+        Add(string, PrintString(v));
+    od;
+    Add(string, "\<\<])");
+    return Concatenation(string);
+end);
+
+InstallMethod(String, "for hashmaps",
+    [ IsHashMapRep ],
+function(ht)
+    local v, first, string;
+    string := [];
+    Add(string, "HashMap([");
+    first := true;
+    for v in KeyValueIterator(ht) do
+        if first then
+            first := false;
+        else
+            Add(string, ", ");
+        fi;
+        Add(string, String(v));
+    od;
+    Add(string, "])");
+    return Concatenation(string);
 end);
 
 #! @Description

--- a/gap/hashmap.gi
+++ b/gap/hashmap.gi
@@ -17,12 +17,17 @@
 
 InstallGlobalFunction(HashMap,
 function(arg...)
-    local hashfunc, eqfunc, capacity;
+    local hashfunc, eqfunc, capacity, values, v, map;
 
+    values := [];
     hashfunc := HashBasic;
     eqfunc := \=;
     capacity := 16;
 
+    if Length(arg) > 0 and IsList(arg[1]) then
+        values := Remove(arg, 1);
+        capacity := Maximum(capacity, Length(values));
+    fi;
     if Length(arg) > 0 and IsFunction(arg[1]) then
         hashfunc := Remove(arg, 1);
     fi;
@@ -36,7 +41,17 @@ function(arg...)
         Error("Invalid arguments");
     fi;
 
-    return DS_Hash_Create(hashfunc, eqfunc, capacity, false);
+
+    map := DS_Hash_Create(hashfunc, eqfunc, capacity, false);
+
+    for v in values do
+        if Length(v) <> 2 then
+            Error("Invalid initial values");
+        fi;
+        map[v[1]] := v[2];
+    od;
+
+    return map;
 end);
 
 InstallMethod(ViewString, "for hash maps",

--- a/gap/hashset.gd
+++ b/gap/hashset.gd
@@ -27,7 +27,9 @@ DeclareRepresentation( "IsHashSetRep", IsHashSet and IsPositionalObjectRep, [] )
 BindGlobal( "HashSetType", NewType(HashSetFamily, IsHashSetRep and IsMutable) );
 
 #! @Description
-#! Create a new hashset. The optional argument <A>hashfunc</A> must be a hash-
+#! Create a new hashset. The optional argument <A>values</A> must be a list of values,
+#! which will be inserted into the new hashset in order.
+#! The optional argument <A>hashfunc</A> must be a hash-
 #! function, <A>eqfunc</A> must
 #! be a binary equality testing function that returns <K>true</K> if the two arguments
 #! are considered equal, and <K>false</K> if they are not. Refer to Chapter
@@ -35,5 +37,5 @@ BindGlobal( "HashSetType", NewType(HashSetFamily, IsHashSetRep and IsMutable) );
 #! equality testers.
 #! The optional argument <A>capacity</A> determines the initial size of the hashmap.
 #!
-#! @Arguments [hashfunc[, eqfunc]] [capacity]
+#! @Arguments [values] [hashfunc[, eqfunc]] [capacity]
 DeclareGlobalFunction("HashSet");

--- a/gap/hashset.gi
+++ b/gap/hashset.gi
@@ -16,12 +16,17 @@
 #! @Section API
 InstallGlobalFunction(HashSet,
 function(arg...)
-    local hashfunc, eqfunc, capacity, res;
+    local hashfunc, eqfunc, capacity, res, values, v;
 
+    values := [];
     hashfunc := HashBasic;
     eqfunc := \=;
     capacity := 16;
 
+    if Length(arg) > 0 and IsList(arg[1]) then
+        values := Remove(arg, 1);
+        capacity := Maximum(capacity, Length(values));
+    fi;
     if Length(arg) > 0 and IsFunction(arg[1]) then
         hashfunc := Remove(arg, 1);
     fi;
@@ -36,6 +41,9 @@ function(arg...)
     fi;
 
     res := DS_Hash_Create(hashfunc, eqfunc, capacity, true);
+    for v in values do
+        AddSet(res, v);
+    od;
     return res;
 end);
 

--- a/gap/hashset.gi
+++ b/gap/hashset.gi
@@ -47,11 +47,42 @@ function(arg...)
     return res;
 end);
 
-InstallMethod(ViewObj, "for hashsets",
+InstallMethod(PrintString, "for hashsets",
     [ IsHashSetRep ],
 function(ht)
-    Print("<hash set obj capacity=",DS_Hash_Capacity(ht),
-            " used=",DS_Hash_Used(ht),">");
+    local v, first, string;
+    string := [];
+    Add(string, "HashSet([\>\>");
+    first := true;
+    for v in ht do
+        if first then
+            first := false;
+        else
+            Add(string, ",\< \>");
+        fi;
+        Add(string, PrintString(v));
+    od;
+    Add(string, "\<\<])");
+    return Concatenation(string);
+end);
+
+InstallMethod(String, "for hashsets",
+    [ IsHashSetRep ],
+function(ht)
+    local v, first, string;
+    string := [];
+    Add(string, "HashSet([");
+    first := true;
+    for v in ht do
+        if first then
+            first := false;
+        else
+            Add(string, ", ");
+        fi;
+        Add(string, String(v));
+    od;
+    Add(string, "])");
+    return Concatenation(string);
 end);
 
 #! @Description

--- a/tst/hashmap.tst
+++ b/tst/hashmap.tst
@@ -36,6 +36,17 @@ true
 gap> Set(List(KeyValueIterator(hashmap))) = List([1..1000],i->[i,i^2]);
 true
 
+# Check initial construction
+gap> Set(List(KeyValueIterator(HashMap([])))) = [];
+true
+gap> Set(List(KeyValueIterator(HashMap([[1,2],[3,4]])))) = [[1,2],[3,4]];
+true
+
+# Check different equality and hash functions
+gap> h := HashMap([[20,1],[11,2],[10,3],[21,4]], x -> x mod 2, {x,y} -> (x mod 10 = y mod 10));;
+gap> Set(List(KeyValueIterator(h)));
+[ [ 11, 4 ], [ 20, 3 ] ]
+
 # check for presence of objects known to be contained in the hash map
 gap> DS_Hash_Contains(hashmap, 42);
 true

--- a/tst/hashmap.tst
+++ b/tst/hashmap.tst
@@ -5,7 +5,7 @@ gap> START_TEST("hashmap.tst");
 # Test hash map with integer keys
 #
 gap> hashmap := HashMap();
-<hash map obj capacity=16 used=0>
+HashMap([])
 
 # keys and values
 gap> Keys(hashmap);
@@ -40,6 +40,24 @@ true
 gap> Set(List(KeyValueIterator(HashMap([])))) = [];
 true
 gap> Set(List(KeyValueIterator(HashMap([[1,2],[3,4]])))) = [[1,2],[3,4]];
+true
+
+# printing
+gap> HashMap();
+HashMap([])
+gap> HashMap([]);
+HashMap([])
+gap> HashMap([[2,3]]);
+HashMap([[ 2, 3 ]])
+gap> String(HashMap([[2,3]]));
+"HashMap([[ 2, 3 ]])"
+gap> String(HashMap([[2,3],[3,4]])) in
+> ["HashMap([[ 2, 3 ], [ 3, 4 ]])","HashMap([[ 3, 4 ], [ 2, 3 ]])"];
+true
+gap> PrintString(HashMap([[2,3]]));
+"HashMap([\>\>[ 2, 3 ]\<\<])"
+gap> PrintString(HashMap([[2,3],[3,4]]))
+> in ["HashMap([\>\>[ 2, 3 ],\< \>[ 3, 4 ]\<\<])","HashMap([\>\>[ 3, 4 ],\< \>[ 2, 3 ]\<\<])"];
 true
 
 # Check different equality and hash functions
@@ -206,15 +224,15 @@ false
 
 # test input validation for HashMap
 gap> HashMap();
-<hash map obj capacity=16 used=0>
+HashMap([])
 gap> HashMap(IdFunc);
-<hash map obj capacity=16 used=0>
+HashMap([])
 gap> HashMap(20);
-<hash map obj capacity=32 used=0>
+HashMap([])
 gap> HashMap(IdFunc, \=);
-<hash map obj capacity=16 used=0>
+HashMap([])
 gap> HashMap(IdFunc, 20);
-<hash map obj capacity=32 used=0>
+HashMap([])
 
 #
 gap> HashMap(fail);
@@ -310,25 +328,25 @@ Error, <iter> is exhausted
 # test reserving capacity
 #
 gap> hashmap := HashMap();
-<hash map obj capacity=16 used=0>
+HashMap([])
 gap> for i in [1..1400] do DS_Hash_SetValue(hashmap, i, i^2); od;
-gap> hashmap;
-<hash map obj capacity=2048 used=1400>
+gap> [Size(hashmap), DS_Hash_Capacity(hashmap)];
+[ 1400, 2048 ]
 
 # delete a few keys to make sure this case is handled, too
 gap> for i in [300..499] do DS_Hash_Delete(hashmap, i); od;
-gap> hashmap;
-<hash map obj capacity=2048 used=1200>
+gap> [Size(hashmap), DS_Hash_Capacity(hashmap)];
+[ 1200, 2048 ]
 
 # trying to shrink does nothing
 gap> DS_Hash_Reserve(hashmap, 200);
-gap> hashmap;
-<hash map obj capacity=2048 used=1200>
+gap> [Size(hashmap), DS_Hash_Capacity(hashmap)];
+[ 1200, 2048 ]
 
 # reserving more space does something
 gap> DS_Hash_Reserve(hashmap, 3000);
-gap> hashmap;
-<hash map obj capacity=4096 used=1200>
+gap> [Size(hashmap), DS_Hash_Capacity(hashmap)];
+[ 1200, 4096 ]
 
 ##########################################
 #
@@ -336,7 +354,7 @@ gap> hashmap;
 #
 #
 gap> hashmap := HashMap();
-<hash map obj capacity=16 used=0>
+HashMap([])
 
 # add stuff
 gap> keys := List([1..1000], i -> String(HashKeyBag(2^100+i, 0,0,-1)));;
@@ -374,7 +392,7 @@ true
 # namely: identity.
 #
 gap> hashmap := HashMap( {x} -> (HANDLE_OBJ(x) mod 2^20), IsIdenticalObj );
-<hash map obj capacity=16 used=0>
+HashMap([])
 gap> hashmap["foo"] := 1;;
 gap> hashmap["foo"] := 2;;
 gap> DS_Hash_Contains(hashmap, "foo");
@@ -404,11 +422,11 @@ gap> hashmap[foo];
 # Test mutability
 #
 gap> hashmap := HashMap();
-<hash map obj capacity=16 used=0>
+HashMap([])
 gap> hashmap[15] := "";
 ""
 gap> MakeImmutable(hashmap);
-<hash map obj capacity=16 used=1>
+HashMap([[ 15, "" ]])
 gap> IsMutable(hashmap);
 false
 gap> hashmap[15] := "2";

--- a/tst/hashset.tst
+++ b/tst/hashset.tst
@@ -22,6 +22,10 @@ gap> s:=AsSet(hashset); IsMutable(s);
 false
 gap> List(Iterator(hashset));
 [  ]
+gap> Set(HashSet([])) = [];
+true
+gap> s := Set(HashSet([1,2,3])) = [1,2,3];
+true
 
 # add stuff
 gap> for p in primes do AddSet(hashset, p); od;
@@ -100,6 +104,11 @@ gap> Set(hashset);
 [  ]
 gap> List(Iterator(hashset));
 [  ]
+
+# Check different equality and hash functions
+gap> h := HashSet([20,11,10,21], x -> x mod 2, {x,y} -> (x mod 10 = y mod 10));;
+gap> Set(h);
+[ 11, 20 ]
 
 #
 # error

--- a/tst/hashset.tst
+++ b/tst/hashset.tst
@@ -9,7 +9,7 @@ gap> primes := Filtered([1..N], IsPrimeInt);;
 
 # create new empty hash set
 gap> hashset := HashSet();
-<hash set obj capacity=16 used=0>
+HashSet([])
 gap> IsEmpty(hashset);
 true
 
@@ -25,6 +25,22 @@ gap> List(Iterator(hashset));
 gap> Set(HashSet([])) = [];
 true
 gap> s := Set(HashSet([1,2,3])) = [1,2,3];
+true
+
+# printing
+gap> HashSet();
+HashSet([])
+gap> HashSet([]);
+HashSet([])
+gap> HashSet([2]);
+HashSet([2])
+gap> String(HashSet([2]));
+"HashSet([2])"
+gap> String(HashSet([2,3])) in ["HashSet([2, 3])","HashSet([3, 2])"];
+true
+gap> PrintString(HashSet([2]));
+"HashSet([\>\>2\<\<])"
+gap> PrintString(HashSet([2,3])) in ["HashSet([\>\>2,\< \>3\<\<])","HashSet([\>\>3,\< \>2\<\<])"];
 true
 
 # add stuff
@@ -121,13 +137,11 @@ Error, <iter> is exhausted
 
 # mutability
 gap> hashset := HashSet();
-<hash set obj capacity=16 used=0>
+HashSet([])
 gap> AddSet(hashset, 15);
 gap> MakeImmutable(hashset);
-<hash set obj capacity=16 used=1>
+HashSet([15])
 gap> AddSet(hashset, 15);
 Error, <ht> must be a mutable hashmap or hashset
 gap> RemoveSet(hashset, 20);
 Error, <ht> must be a mutable hashmap or hashset
-
-


### PR DESCRIPTION
This fixes two irritations I had with HashMap and HashSet.

(1) You can now give an initial value, as `HashSet([1,2,3])`, or `HashMap([ [1,2], [3,4] ])` (the hashmap notation is less nice, but I didn't have a nicer one).

(2) The printing of hashsets and hashmaps now prints their values -- it actually prints out this notation, so it can be used to later read them back in.