### PR TITLE
Make sure rec(1:=2,3:=4) and rec(1:=4,2:=3) have different hashes

### DIFF
--- a/src/hashfunctions.c
+++ b/src/hashfunctions.c
@@ -164,11 +164,11 @@ Int BasicRecursiveHashForList(Obj obj)
     for (Int pos = 1; pos <= len; ++pos) {
         Obj val = ELM0_LIST(obj, pos);
         if (val == 0) {
-            current_hash = HashCombine2(current_hash, ~(Int)0);
+            current_hash = AddToHash(current_hash, ~(Int)0);
         }
         else {
             current_hash =
-                HashCombine2(current_hash, BasicRecursiveHash(val));
+                AddToHash(current_hash, BasicRecursiveHash(val));
         }
     }
     return current_hash;
@@ -193,7 +193,7 @@ Int BasicRecursiveHashForPRec(Obj obj)
         UInt rechash = BasicRecursiveHash(GET_ELM_PREC(obj, i));
 
         // Use +, because record may be out of order
-        current_hash += HashCombine2(hashrecname, rechash);
+        current_hash += AddToHash(hashrecname, rechash);
     }
 
     return current_hash;
@@ -256,8 +256,8 @@ Obj DATA_HASH_FUNC_RECURSIVE2(Obj self, Obj obj1, Obj obj2)
     UInt hash1 = BasicRecursiveHash(obj1);
     UInt hash2 = BasicRecursiveHash(obj2);
 
-    UInt listhash1 = HashCombine2(LIST_BASE_HASH, hash1);
-    UInt listhash2 = HashCombine2(listhash1, hash2);
+    UInt listhash1 = AddToHash(LIST_BASE_HASH, hash1);
+    UInt listhash2 = AddToHash(listhash1, hash2);
     
     return HashValueToObjInt(listhash2);
 }
@@ -268,9 +268,9 @@ Obj DATA_HASH_FUNC_RECURSIVE3(Obj self, Obj obj1, Obj obj2, Obj obj3)
     Int hash2 = BasicRecursiveHash(obj2);
     Int hash3 = BasicRecursiveHash(obj3);
 
-    UInt listhash1 = HashCombine2(LIST_BASE_HASH, hash1);
-    UInt listhash2 = HashCombine2(listhash1, hash2);
-    UInt listhash3 = HashCombine2(listhash2, hash3);
+    UInt listhash1 = AddToHash(LIST_BASE_HASH, hash1);
+    UInt listhash2 = AddToHash(listhash1, hash2);
+    UInt listhash3 = AddToHash(listhash2, hash3);
 
     return HashValueToObjInt(listhash3);
 }
@@ -282,10 +282,10 @@ Obj DATA_HASH_FUNC_RECURSIVE4(Obj self, Obj obj1, Obj obj2, Obj obj3, Obj obj4)
     Int hash3 = BasicRecursiveHash(obj3);
     Int hash4 = BasicRecursiveHash(obj4);
 
-    UInt listhash1 = HashCombine2(LIST_BASE_HASH, hash1);
-    UInt listhash2 = HashCombine2(listhash1, hash2);
-    UInt listhash3 = HashCombine2(listhash2, hash3);
-    UInt listhash4 = HashCombine2(listhash3, hash4);
+    UInt listhash1 = AddToHash(LIST_BASE_HASH, hash1);
+    UInt listhash2 = AddToHash(listhash1, hash2);
+    UInt listhash3 = AddToHash(listhash2, hash3);
+    UInt listhash4 = AddToHash(listhash3, hash4);
 
     return HashValueToObjInt(listhash4);
 }

--- a/src/hashfunctions.h
+++ b/src/hashfunctions.h
@@ -47,8 +47,8 @@ static UInt ShuffleUInt(UInt key)
     return key;
 }
 
-// Hash two integers together -- comes from implementation in Boost
-static inline UInt HashCombine2(UInt seed, UInt v)
+// Combine a new value with an existing hash value
+static inline UInt AddToHash(UInt seed, UInt v)
 {
     return seed ^ (ShuffleUInt(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2));
 }

--- a/src/hashfunctions.h
+++ b/src/hashfunctions.h
@@ -19,29 +19,6 @@
 
 extern struct DatastructuresModule HashFunctionsModule;
 
-
-// Hash two integers together
-static inline UInt HashCombine2(UInt hash1, UInt hash2)
-{
-    return 184950419 * hash1 + hash2;
-}
-
-static inline UInt HashCombine3(UInt hash1, UInt hash2, UInt hash3)
-{
-    return 79504963 * hash1 + 3287951041 * hash2 + hash3;
-}
-
-// Transform a UInt into a signed GAP intermediate integer, shrinking
-// the size of the number as required
-static inline Obj HashValueToObjInt(UInt uhash)
-{
-    Int hash = (Int)uhash;
-    // Make sure bottom bits are not lost
-    hash += hash << 11;
-    hash /= 16;
-    return INTOBJ_INT(hash);
-}
-
 // Perform a shuffle of a UInt. Ideally, changing any
 // bit would have a 50/50 chance of changing every other bit.
 // The main purpose of this is to allow adding values when
@@ -69,5 +46,23 @@ static UInt ShuffleUInt(UInt key)
 #endif
     return key;
 }
+
+// Hash two integers together -- comes from implementation in Boost
+static inline UInt HashCombine2(UInt seed, UInt v)
+{
+    return seed ^ (ShuffleUInt(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2));
+}
+
+// Transform a UInt into a signed GAP intermediate integer, shrinking
+// the size of the number as required
+static inline Obj HashValueToObjInt(UInt uhash)
+{
+    Int hash = (Int)uhash;
+    // Make sure bottom bits are not lost
+    hash += hash << 11;
+    hash /= 16;
+    return INTOBJ_INT(hash);
+}
+
 
 #endif

--- a/tst/hashfunctions/recursive.tst
+++ b/tst/hashfunctions/recursive.tst
@@ -52,6 +52,12 @@ gap> rec2.aaap := 8;; rec2.aaaq := 9;;
 gap> HashBasic(rec1) = HashBasic(rec2);
 true
 
+# Make sure 'similar' objects have different hashes
+gap> Size(Set([rec(), rec(1 := 2), rec(2 := 1), rec(1 := 2, 3 := 4), rec(1 := 4, 3 := 2)], HashBasic));
+5
+gap> Size(Set([ [], [1], [1,1], [2], [2,1], [2,2]], HashBasic));
+6
+
 # Check objects we don't handle
 # FIXME: disabled due to differences in printing between GAP 4.10 and 4.11
 #gap> HashBasic(SymmetricGroup(3));


### PR DESCRIPTION
As in title, fixes a bug where rec(1:=2,3:=4) and rec(1:=4,2:=3) had the same hash.

Add some tests that make sure a selection of basic objects don't have hash collisions (obviously these could still hypothetically collide by extremely bad luck, but they do not).