### PR TITLE
Don't use identity as hash func for small ints

### DIFF
--- a/src/hashfunctions.c
+++ b/src/hashfunctions.c
@@ -145,7 +145,7 @@ Obj DATA_HASH_FUNC_FOR_INT(Obj self, Obj i)
     }
 
     if (IS_INTOBJ(i))
-        return i;
+        return HashValueToObjInt(ShuffleUInt((UInt)i));
     else
         return HashValueToObjInt(DataHashFuncForInt(i));
 }


### PR DESCRIPTION
This is a bad idea in many applications
