### PR TITLE
Avoid undefined behavior in HashValueToObjInt

### DIFF
--- a/src/hashfunctions.h
+++ b/src/hashfunctions.h
@@ -56,10 +56,9 @@ static inline UInt AddToHash(UInt seed, UInt v)
 // the size of the number as required
 static inline Obj HashValueToObjInt(UInt uhash)
 {
-    Int hash = (Int)uhash;
     // Make sure bottom bits are not lost
-    hash += hash << 11;
-    hash /= 16;
+    uhash += uhash << 11;
+    Int hash = (Int)uhash / 16;
     return INTOBJ_INT(hash);
 }
 


### PR DESCRIPTION
When datastructures is built with UBSAN, the undefined behavior sanitizer, the sanitizer complains:
```
src/hashfunctions.h:61:18: runtime error: left shift of 2851389363498048825 by 11 places cannot be represented in type 'long int'
```
Overflow of signed integers is undefined behavior in C, because the result depends on whether two's complement is in use or not.  Both the shift and the addition can overflow, so do both with the unsigned value, then cast to a signed integer before the division.

Note that I am not claiming that the current code produces incorrect results.  It probably does on all current architectures with current compilers.  But some future compiler may introduce an optimization that assumes the absence of undefined behavior, which could cause problems with this code.